### PR TITLE
Hotfix: pass user_id to planner_repo for active entry sync

### DIFF
--- a/backend/app/services/recipe_service.py
+++ b/backend/app/services/recipe_service.py
@@ -72,7 +72,7 @@ class RecipeService:
 
         # Check if any of those meals are in active planner entries
         for meal in meals_with_recipe:
-            entries = planner_repo.get_by_meal_id(meal.id)
+            entries = planner_repo.get_by_meal_id(meal.id, self.user_id)
             active_entries = [e for e in entries if not e.is_completed and not e.is_cleared]
             if active_entries:
                 # Found at least one active entry, sync and return


### PR DESCRIPTION
## Summary
- Fix missing `user_id` parameter in `planner_repo.get_by_meal_id` call for active entry sync

## Changes
- `backend/app/services/recipe_service.py` — pass `user_id` to planner repo query

## Test Plan
- [ ] Verify active planner entries sync correctly after recipe updates
- [ ] Confirm no auth regression on planner operations

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)