### PR TITLE
fix: auto-populate meal name with recipe name on create

### DIFF
--- a/frontend/src/app/recipes/[id]/_components/AddToMealPlanDialog.tsx
+++ b/frontend/src/app/recipes/[id]/_components/AddToMealPlanDialog.tsx
@@ -195,7 +195,10 @@ export function AddToMealPlanDialog({
             <div className="space-y-2 max-h-[300px] overflow-y-auto py-2 px-6 -mx-6">
               {/* Create new meal button */}
               <button
-                onClick={() => setMode("create")}
+                onClick={() => {
+                  setMode("create");
+                  setNewMealName(recipe.recipe_name);
+                }}
                 className="w-full p-4 rounded-lg border border-dashed border-primary/50 bg-elevated text-left transition-colors hover:bg-hover hover:border-primary"
               >
                 <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
This PR implements auto-population of the meal name input when creating a new meal from the "Add to Meal Plan" dialog.

## Changes
- Modified the "Create new meal" button onClick handler to pre-fill `newMealName` with `recipe.recipe_name`
- The input remains fully editable while providing a sensible default

## Testing
- When clicking "Create new meal" from a recipe's "Add to Meal Plan" dialog, the meal name input should now be pre-filled with the recipe name
- Users can still edit the name before creating the meal

Fixes #63

Generated with [Claude Code](https://claude.ai/code)