### PR TITLE
Hotfix: Fix recipe groups not working as filters

### DIFF
--- a/backend/app/api/recipes.py
+++ b/backend/app/api/recipes.py
@@ -41,6 +41,9 @@ def _recipe_to_response_dto(recipe) -> RecipeResponseDTO:
             unit=ri.unit,
         ))
 
+    # Extract group IDs from the recipe's groups relationship
+    group_ids = [group.id for group in recipe.groups] if recipe.groups else []
+
     return RecipeResponseDTO(
         id=recipe.id,
         recipe_name=recipe.recipe_name,
@@ -56,6 +59,7 @@ def _recipe_to_response_dto(recipe) -> RecipeResponseDTO:
         is_favorite=recipe.is_favorite,
         created_at=recipe.created_at.isoformat() if recipe.created_at else None,
         ingredients=ingredients,
+        group_ids=group_ids,
     )
 
 

--- a/backend/app/dtos/recipe_dtos.py
+++ b/backend/app/dtos/recipe_dtos.py
@@ -155,6 +155,7 @@ class RecipeResponseDTO(RecipeBaseDTO):
     is_favorite: bool = False
     created_at: Optional[str] = None  # ISO format datetime string
     ingredients: List["RecipeIngredientResponseDTO"] = []
+    group_ids: List[int] = []  # IDs of recipe groups this recipe belongs to
 
 # ── Filter DTO ──────────────────────────────────────────────────────────────────────────────────────────────
 class RecipeFilterDTO(BaseModel):

--- a/frontend/src/lib/recipeCardMapper.ts
+++ b/frontend/src/lib/recipeCardMapper.ts
@@ -44,6 +44,7 @@ export function mapRecipeForCard(dto: RecipeResponseDTO): RecipeCardData {
     isFavorite: dto.is_favorite ?? false,
     ingredients: dto.ingredients?.map(mapIngredientForCard) ?? [],
     createdAt: dto.created_at ?? undefined,
+    groupIds: dto.group_ids ?? [],
   };
 }
 

--- a/frontend/src/types/recipe.ts
+++ b/frontend/src/types/recipe.ts
@@ -65,6 +65,7 @@ export interface RecipeResponseDTO extends RecipeBaseDTO {
   is_favorite: boolean;
   created_at: string | null;
   ingredients: RecipeIngredientResponseDTO[];
+  group_ids: number[]; // IDs of recipe groups this recipe belongs to
 }
 
 export interface RecipeCardDTO {


### PR DESCRIPTION
## 🚨 Production Hotfix

### Issue
Recipe groups filter was completely broken - selecting any recipe group filter would cause all recipes to be filtered out, making recipe groups unusable as a filtering mechanism.

### Root Cause
`group_ids` was never populated in the API response at any layer:
1. Backend DTO (`RecipeResponseDTO`) lacked `group_ids` field
2. Backend API (`_recipe_to_response_dto`) didn't extract groups from the recipe model
3. Frontend mapper (`mapRecipeForCard`) didn't map `group_ids`

The filter logic itself was correct, but it was filtering against empty data (every recipe had `groupIds: undefined`).

### Fix
- Added `group_ids: List[int]` to `RecipeResponseDTO` (backend)
- Extract group IDs from `recipe.groups` relationship in API response builder
- Added `group_ids` to frontend `RecipeResponseDTO` type
- Map `group_ids` in `recipeCardMapper`

### Risk Assessment
- **Impact**: Low - adds data to existing API response
- **Scope**: 4 files, 7 lines of code
- **Testing**: Filter logic already existed and worked correctly, just needed data

### Checklist
- [x] Fix verified locally
- [x] No other side effects
- [x] TypeScript compiles successfully
- [x] Minimal change footprint

---
⚠️ This will deploy immediately to production via Railway

🤖 Generated with Claude Code