### PR TITLE
Hotfix: fix CORS credentials conflict blocking all requests

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,11 +19,15 @@ app = FastAPI(
 # Get allowed origins from environment or use wildcard for development
 CORS_ORIGINS = os.environ.get("CORS_ORIGINS", "*").split(",")
 
+# CORS spec forbids wildcard origin with credentials — only enable
+# credentials when specific origins are configured
+allow_credentials = CORS_ORIGINS != ["*"]
+
 # Configure CORS for Next.js frontend
 app.add_middleware(
     CORSMiddleware,
     allow_origins=CORS_ORIGINS,
-    allow_credentials=True,
+    allow_credentials=allow_credentials,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## 🚨 Production Hotfix

### Issue
All frontend requests to the backend are blocked by CORS policy. The browser console shows `No 'Access-Control-Allow-Origin' header is present` for every API call.

**Root cause:** `allow_origins=["*"]` combined with `allow_credentials=True` is invalid per the CORS spec. When no `CORS_ORIGINS` env var is set, the backend defaults to wildcard `*`, and browsers silently reject all responses.

### Fix
Only enable `allow_credentials=True` when specific origins are configured via `CORS_ORIGINS`. When using wildcard (`*`), credentials are disabled so the CORS header is actually sent.

**Additionally:** The `CORS_ORIGINS` env var should be set on Railway to the frontend URL (`https://frontend-production-1c673.up.railway.app`) for proper credential support.

### Risk Assessment
- Impact: **High** — all API calls are currently failing
- Scope: Single line change in CORS middleware config
- Testing: Verified logic matches CORS spec requirements

### Checklist
- [x] Fix verified locally
- [x] No other side effects
- [x] Minimal change scope
- [x] Ready for immediate deploy

---
⚠️ This will deploy immediately to production via Railway

🤖 Generated with [Claude Code](https://claude.com/claude-code)