### PR TITLE
fix: handle Gemini 3.x tool-call preamble in assistant response

### DIFF
--- a/backend/app/services/ai/assistant/service.py
+++ b/backend/app/services/ai/assistant/service.py
@@ -154,6 +154,14 @@ class AssistantServiceCore:
         if not response or not response.candidates:
             return {"type": "error", "response": None, "error": "No response from AI"}
 
+        # Gemini 3.x may emit a conversational preamble text part *before* the
+        # function_call part (e.g. "Here are some ideas! 🔍"). We must scan all
+        # parts and prioritize the function call over any preamble text —
+        # otherwise we'd return the preamble as a plain chat reply and never
+        # execute the tool, dropping the suggestions/recipe entirely.
+        function_call = None
+        text_response = None
+
         for candidate in response.candidates:
             if not candidate.content or not candidate.content.parts:
                 continue
@@ -162,21 +170,39 @@ class AssistantServiceCore:
                 if hasattr(part, "thought") and part.thought:
                     continue
 
-                # Check for function call
-                if hasattr(part, "function_call") and part.function_call:
-                    return self._handle_function_call(
-                        part.function_call.name,
-                        dict(part.function_call.args) if part.function_call.args else {},
-                        user_context_data,
-                        contents,
-                    )
+                # Capture the first function call we encounter.
+                if (
+                    function_call is None
+                    and hasattr(part, "function_call")
+                    and part.function_call
+                ):
+                    function_call = part.function_call
+                    continue
 
-                # Regular text response
-                if hasattr(part, "text") and part.text:
-                    return {
-                        "type": "chat",
-                        "response": part.text.strip(),
-                    }
+                # Capture the first non-empty text part as a fallback.
+                if (
+                    text_response is None
+                    and hasattr(part, "text")
+                    and part.text
+                    and part.text.strip()
+                ):
+                    text_response = part.text.strip()
+
+        # A tool call always takes precedence over preamble text.
+        if function_call is not None:
+            return self._handle_function_call(
+                function_call.name,
+                dict(function_call.args) if function_call.args else {},
+                user_context_data,
+                contents,
+            )
+
+        # No tool call — this was a plain conversational reply.
+        if text_response is not None:
+            return {
+                "type": "chat",
+                "response": text_response,
+            }
 
         return {"type": "error", "response": None, "error": "Could not parse response"}
 

--- a/backend/tests/test_assistant_service.py
+++ b/backend/tests/test_assistant_service.py
@@ -1,0 +1,130 @@
+"""Tests for the AI assistant response processing.
+
+Regression coverage for the Gemini 3.x behavior change where the model emits a
+conversational preamble text part *before* the function_call part. The response
+processor must prioritize the function call over the preamble text, otherwise
+the preamble ("Here are some ideas! 🔍") is returned as a plain chat reply and
+the tool (e.g. suggest_recipes) never executes.
+"""
+
+from unittest.mock import MagicMock
+
+from app.services.ai.assistant import AssistantService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _text_part(text: str):
+    """A response part containing only text."""
+    part = MagicMock()
+    part.thought = False
+    part.function_call = None
+    part.text = text
+    return part
+
+
+def _function_call_part(name: str, args: dict):
+    """A response part containing only a function call."""
+    fc = MagicMock()
+    fc.name = name
+    fc.args = args
+
+    part = MagicMock()
+    part.thought = False
+    part.function_call = fc
+    part.text = None
+    return part
+
+
+def _make_response(parts: list):
+    """Wrap parts in a mock Gemini GenerateContentResponse."""
+    content = MagicMock()
+    content.parts = parts
+
+    candidate = MagicMock()
+    candidate.content = content
+
+    response = MagicMock()
+    response.candidates = [candidate]
+    return response
+
+
+def _make_service() -> AssistantService:
+    """Build a service instance without running __init__ (skips client setup)."""
+    return AssistantService.__new__(AssistantService)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_function_call_takes_precedence_over_preamble_text():
+    """Preamble text before a function call must not short-circuit the tool."""
+    service = _make_service()
+    service._handle_function_call = MagicMock(
+        return_value={"type": "suggestions", "response": "..."}
+    )
+
+    response = _make_response(
+        [
+            _text_part("Here are some ideas! 🔍"),
+            _function_call_part("suggest_recipes", {"main_ingredient": "chicken"}),
+        ]
+    )
+
+    result = service._process_response(response, user_context_data=None, contents=[])
+
+    service._handle_function_call.assert_called_once()
+    called_tool = service._handle_function_call.call_args.args[0]
+    called_args = service._handle_function_call.call_args.args[1]
+    assert called_tool == "suggest_recipes"
+    assert called_args == {"main_ingredient": "chicken"}
+    assert result["type"] == "suggestions"
+
+
+def test_function_call_handled_when_it_is_the_only_part():
+    """Gemini 2.x style: a bare function_call part still routes to the tool."""
+    service = _make_service()
+    service._handle_function_call = MagicMock(
+        return_value={"type": "recipe", "response": "..."}
+    )
+
+    response = _make_response(
+        [_function_call_part("create_recipe", {"recipe_name": "Tacos"})]
+    )
+
+    service._process_response(response, user_context_data=None, contents=[])
+
+    service._handle_function_call.assert_called_once()
+    assert service._handle_function_call.call_args.args[0] == "create_recipe"
+
+
+def test_plain_text_returns_chat():
+    """A text-only response (casual conversation) returns a chat reply."""
+    service = _make_service()
+
+    response = _make_response([_text_part("Honestly, I'm doing great! 💛")])
+
+    result = service._process_response(response, user_context_data=None, contents=[])
+
+    assert result["type"] == "chat"
+    assert result["response"] == "Honestly, I'm doing great! 💛"
+
+
+def test_thought_parts_are_ignored():
+    """Thinking parts must not be mistaken for the conversational reply."""
+    service = _make_service()
+
+    thought = MagicMock()
+    thought.thought = True
+    thought.function_call = None
+    thought.text = "internal reasoning..."
+
+    response = _make_response([thought, _text_part("The real answer ✨")])
+
+    result = service._process_response(response, user_context_data=None, contents=[])
+
+    assert result["type"] == "chat"
+    assert result["response"] == "The real answer ✨"


### PR DESCRIPTION
## Summary

Fixes the Meal Genie assistant silently dropping recipe suggestions and recipe generations after the Gemini 2.x → 3.x migration. Casual conversation worked, but any request that should trigger a tool (e.g. "dinner ideas?") only surfaced a preamble like "Here are some ideas! 🔍" with nothing following.

## Root cause

This is a **behavioral change** in Gemini 3.x, not a model-name issue.

`_process_response` in `backend/app/services/ai/assistant/service.py` walked the response parts **in order** and returned on the *first* part that was either text or a function call.

- **Gemini 2.x**: when calling a tool, returned *only* a `function_call` part → routed correctly.
- **Gemini 3.x**: now emits a conversational **preamble text part *before* the `function_call`** in the same response:
  ```
  [ Part(text="Here are some ideas! 🔍"), Part(function_call=suggest_recipes(...)) ]
  ```
  The loop hit the text part first, returned it as a plain `chat` reply, and **never executed the tool** — so suggestions/recipes were silently dropped. No backend error was raised because, from the code's view, it returned a valid chat response.

Casual chat was unaffected (text-only, no function call). The other AI services (recipe generation, tips, nutrition, images) were unaffected because they don't use function calling.

## The fix

`_process_response` now scans **all** parts and **prioritizes the function call** over any preamble text, only falling back to text when there's no tool call. Thought parts are still skipped.

## Testing

- Added `backend/tests/test_assistant_service.py` (4 tests): preamble-before-tool-call, bare tool call, plain text, and thought-part handling.
- Confirmed the key regression test **fails against the old code** (tool called 0 times) and **passes with the fix**.
- No regressions introduced; pre-existing unrelated test-environment failures (`cffi`/cryptography native module) are untouched.

https://claude.ai/code/session_016GawC2sq32N2v8oZVpaZXT

---
_Generated by [Claude Code](https://claude.ai/code/session_016GawC2sq32N2v8oZVpaZXT)_