### PR TITLE
Hotfix: eliminate N+1 database queries in recipe list and shopping sync

### DIFF
--- a/backend/app/repositories/recipe_repo.py
+++ b/backend/app/repositories/recipe_repo.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import Optional
 
 from sqlalchemy import func, select
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session, joinedload, selectinload
 
 from ..dtos.recipe_dtos import (
     RecipeCreateDTO,
@@ -387,8 +387,14 @@ class RecipeRepo:
         Returns:
             List[Recipe]: A list of recipes that match the specified criteria.
         """
-        # Start with a base query to select recipes and eager-load ingredients
-        stmt = select(Recipe).options(joinedload(Recipe.ingredients))
+        # Start with a base query to select recipes and eager-load everything the
+        # response DTO touches (groups and nutrition_facts would otherwise lazy-load
+        # per recipe — an N+1 that is painful over a networked database)
+        stmt = select(Recipe).options(
+            joinedload(Recipe.ingredients),
+            selectinload(Recipe.groups),
+            selectinload(Recipe.nutrition_facts),
+        )
 
         # Always filter by user - users only see their own recipes
         stmt = stmt.where(Recipe.user_id == user_id)

--- a/backend/app/repositories/shopping/__init__.py
+++ b/backend/app/repositories/shopping/__init__.py
@@ -139,6 +139,14 @@ class ShoppingRepo:
         """Delete contributions for item."""
         return self.contribution_repo.delete_contributions_for_item(shopping_item_id)
 
+    def add_contributions(self, contributions):
+        """Add multiple contributions in a single flush."""
+        return self.contribution_repo.add_contributions(contributions)
+
+    def delete_contributions_for_items(self, shopping_item_ids):
+        """Delete contributions for multiple items in one statement."""
+        return self.contribution_repo.delete_contributions_for_items(shopping_item_ids)
+
     def get_contributions_by_entry(self, planner_entry_id):
         """Get contributions by entry."""
         return self.contribution_repo.get_contributions_by_entry(planner_entry_id)

--- a/backend/app/repositories/shopping/contribution_repo.py
+++ b/backend/app/repositories/shopping/contribution_repo.py
@@ -63,6 +63,24 @@ class ShoppingContributionRepo:
         self.session.flush()
         return contribution
 
+    def add_contributions(
+        self, contributions: List[ShoppingItemContribution]
+    ) -> List[ShoppingItemContribution]:
+        """
+        Add multiple contributions in a single flush.
+
+        Args:
+            contributions: ShoppingItemContribution instances to persist
+
+        Returns:
+            The persisted contributions
+        """
+        if not contributions:
+            return []
+        self.session.add_all(contributions)
+        self.session.flush()
+        return contributions
+
     def delete_contributions_for_entry(self, planner_entry_id: int) -> int:
         """
         Delete all contributions from a specific planner entry.
@@ -91,6 +109,24 @@ class ShoppingContributionRepo:
         """
         stmt = delete(ShoppingItemContribution).where(
             ShoppingItemContribution.shopping_item_id == shopping_item_id
+        )
+        result = self.session.execute(stmt)
+        return result.rowcount
+
+    def delete_contributions_for_items(self, shopping_item_ids: List[int]) -> int:
+        """
+        Delete all contributions for multiple shopping items in one statement.
+
+        Args:
+            shopping_item_ids: IDs of the shopping items to clear
+
+        Returns:
+            Number of contributions deleted
+        """
+        if not shopping_item_ids:
+            return 0
+        stmt = delete(ShoppingItemContribution).where(
+            ShoppingItemContribution.shopping_item_id.in_(shopping_item_ids)
         )
         result = self.session.execute(stmt)
         return result.rowcount

--- a/backend/app/services/shopping/sync.py
+++ b/backend/app/services/shopping/sync.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -20,6 +20,7 @@ from ...dtos.shopping_dtos import (
     ShoppingListGenerationResultDTO,
 )
 from ...models.shopping_item import ShoppingItem
+from ...models.shopping_item_contribution import ShoppingItemContribution
 from ...services.unit_conversion_service import UnitConversionService
 from ...utils.unit_conversion import to_display_unit
 
@@ -111,6 +112,11 @@ class SyncMixin:
                 "contributions_synced": 0,
             }
 
+            # Contribution rewrites are collected across the loop and applied in
+            # two bulk statements (delete + insert) instead of per-item round trips
+            items_to_clear: List[int] = []
+            pending_contributions: List[ShoppingItemContribution] = []
+
             # 4. Process each desired aggregation key
             for agg_key, contributions in desired_contributions.items():
                 # Calculate total base quantity
@@ -157,8 +163,8 @@ class SyncMixin:
                     if display_qty > old_qty + 0.01:
                         item.have = False
 
-                    # Sync contributions
-                    self._sync_item_contributions(item, contributions)
+                    # Existing contributions are cleared in bulk after the loop
+                    items_to_clear.append(item.id)
                     stats["items_updated"] += 1
                 else:
                     # Create new item
@@ -170,18 +176,23 @@ class SyncMixin:
                         aggregation_key=agg_key.lower().strip(),
                     )
                     self.shopping_repo.create_shopping_item(item)
-
-                    # Create contributions
-                    self._sync_item_contributions(item, contributions)
                     stats["items_created"] += 1
 
+                pending_contributions.extend(
+                    self._build_contributions(item, contributions)
+                )
                 stats["contributions_synced"] += len(contributions)
 
                 # Remove from all_recipe_items so we know it's not orphaned
                 if agg_key in all_recipe_items:
                     del all_recipe_items[agg_key]
 
-            # 5. Delete orphaned items (items no longer in desired state)
+            # 5. Apply collected contribution rewrites in bulk
+            # (delete must run before the inserts flush so replaced rows are gone first)
+            self.shopping_repo.delete_contributions_for_items(items_to_clear)
+            self.shopping_repo.add_contributions(pending_contributions)
+
+            # 6. Delete orphaned items (items no longer in desired state)
             for agg_key, item in all_recipe_items.items():
                 if agg_key not in desired_contributions:
                     self.shopping_repo.delete_item(item.id)
@@ -197,28 +208,30 @@ class SyncMixin:
             self.session.rollback()
             raise RuntimeError(f"Failed to sync shopping list: {e}") from e
 
-    def _sync_item_contributions(
+    def _build_contributions(
         self, item: ShoppingItem, desired_contributions: Dict[tuple, Dict[str, Any]]
-    ) -> None:
+    ) -> List[ShoppingItemContribution]:
         """
-        Sync contributions for a single shopping item.
+        Build the desired contribution rows for a single shopping item.
+        Rows are persisted in bulk by the caller.
 
         Args:
-            item: The shopping item to sync contributions for
+            item: The shopping item the contributions belong to
             desired_contributions: Dict of (entry_id, recipe_id) -> contribution data
-        """
-        # Delete all existing contributions for this item
-        self.shopping_repo.delete_contributions_for_item(item.id)
 
-        # Create new contributions
-        for (entry_id, recipe_id), data in desired_contributions.items():
-            self.shopping_repo.add_contribution(
+        Returns:
+            Unpersisted ShoppingItemContribution instances
+        """
+        return [
+            ShoppingItemContribution(
                 shopping_item_id=item.id,
                 recipe_id=recipe_id,
                 planner_entry_id=entry_id,
                 base_quantity=data["base_quantity"],
                 dimension=data["dimension"],
             )
+            for (entry_id, recipe_id), data in desired_contributions.items()
+        ]
 
     # -- Generate Methods (for API compatibility) ------------------------------------------------
     def generate_shopping_list(

--- a/backend/app/services/unit_conversion_service.py
+++ b/backend/app/services/unit_conversion_service.py
@@ -5,7 +5,7 @@ Provides services for unit conversion rule management.
 
 # ── Imports ─────────────────────────────────────────────────────────────────────────────────────────────────
 import math
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
@@ -35,6 +35,10 @@ class UnitConversionService:
         self.session = session
         self.user_id = user_id
         self.repo = UnitConversionRepo(session, user_id)
+        # Lazily-built lookup of the user's rules, keyed by
+        # (ingredient_name, from_unit). Loaded once per service instance so
+        # bulk operations (e.g. shopping sync) don't query per item.
+        self._rule_map: Optional[Dict[Tuple[str, str], UnitConversionRule]] = None
 
     # ── CRUD Operations ─────────────────────────────────────────────────────────────────────────────────────
     def get_all(self) -> List[UnitConversionRule]:
@@ -58,6 +62,7 @@ class UnitConversionService:
             )
             self.repo.add(rule)
             self.session.commit()
+            self._invalidate_rule_map()
             return rule
         except SQLAlchemyError as e:
             self.session.rollback()
@@ -84,6 +89,7 @@ class UnitConversionService:
                 rule.round_up = dto.round_up
 
             self.session.commit()
+            self._invalidate_rule_map()
             return rule
         except SQLAlchemyError as e:
             self.session.rollback()
@@ -97,12 +103,26 @@ class UnitConversionService:
                 return False
             self.repo.delete(rule)
             self.session.commit()
+            self._invalidate_rule_map()
             return True
         except SQLAlchemyError as e:
             self.session.rollback()
             raise e
 
     # ── Conversion Logic ────────────────────────────────────────────────────────────────────────────────────
+    def _get_rule_map(self) -> Dict[Tuple[str, str], UnitConversionRule]:
+        """Load all of the user's rules once, keyed by (ingredient_name, from_unit)."""
+        if self._rule_map is None:
+            self._rule_map = {
+                (rule.ingredient_name.lower().strip(), rule.from_unit.lower().strip()): rule
+                for rule in self.repo.get_all()
+            }
+        return self._rule_map
+
+    def _invalidate_rule_map(self) -> None:
+        """Drop the cached rule lookup after a rule mutation."""
+        self._rule_map = None
+
     def apply_conversion(
         self, ingredient_name: str, quantity: float, unit: str
     ) -> Tuple[float, str]:
@@ -118,7 +138,9 @@ class UnitConversionService:
             Tuple of (converted_quantity, converted_unit).
             Returns original values if no matching rule exists.
         """
-        rule = self.repo.find_matching_rule(ingredient_name, unit)
+        rule = self._get_rule_map().get(
+            ((ingredient_name or "").lower().strip(), (unit or "").lower().strip())
+        )
         if not rule:
             return quantity, unit
 


### PR DESCRIPTION
## 🚨 Production Hotfix

### Issue
After the latest deploy, recipe cards in the meal creation dialog took many seconds to load and saving a meal took even longer. Two compounding causes:

1. **Backend N+1 queries** — listing recipes lazy-loaded `groups` and `nutrition_facts` per recipe (~2N+1 queries); the shopping sync ran a conversion-rule lookup per item and a delete + per-row flushed insert per contribution (~370 queries per save).
2. **Database connected over the public proxy** — the backend's `SQLALCHEMY_DATABASE_URL` resolved to `crossover.proxy.rlwy.net`, making every query a public-internet round trip (30–100ms each). Fixed separately in Railway by composing the URL from `RAILWAY_PRIVATE_DOMAIN` (already applied).

### Fix
- `filter_recipes` now eager-loads `groups` and `nutrition_facts` (`selectinload`) — recipe list serializes in 3 queries regardless of recipe count
- `UnitConversionService` loads the user's rules once per instance instead of querying per shopping item (cache invalidated on rule mutations)
- Shopping sync collects contribution rewrites and applies them as one bulk `DELETE` + one bulk insert flush

### Risk Assessment
- Impact: High (restores usable performance in production)
- Scope: Backend only — query loading strategy and batching; no behavior/schema changes
- Testing: pytest 189 passed / 31 failed — failures are the known pre-existing `test_recipe_generation_*` baseline, zero new failures. Smoke test vs dev data: recipe list 163 recipes in 3 queries (was ~327); shopping sync 77 items / 140 contributions in 156 queries (was ~370).

### Checklist
- [x] Fix verified locally
- [x] No other side effects
- [x] Tested on production-like data (dev user 2, full dataset)
- [x] Ready for immediate deploy

---
⚠️ This will deploy immediately to production via Railway

🤖 Generated with [Claude Code](https://claude.com/claude-code)