### PR TITLE
Hotfix: restore missing datetime import in admin_repo

### DIFF
--- a/backend/app/repositories/admin_repo.py
+++ b/backend/app/repositories/admin_repo.py
@@ -4,6 +4,7 @@ Repository layer for admin operations. Handles direct database interactions
 for user management.
 """
 
+from datetime import datetime
 from typing import List, Optional, Tuple
 
 from sqlalchemy import func, select


### PR DESCRIPTION
## 🚨 Production Hotfix

### Issue
Production backend is crash-looping. The prior deploy (PR #133, feedback-handling refactor) trimmed `backend/app/repositories/admin_repo.py` and dropped the `from datetime import datetime` import, while `AdminRepo.update_user_pro_grant` still type-hints a parameter as `datetime`. Since annotations are evaluated at class-body execution time, this raises `NameError: name 'datetime' is not defined` on import, crashing the whole app at startup (confirmed via `railway logs --service backend --environment production --deployment`).

### Fix
Re-add `from datetime import datetime` to `backend/app/repositories/admin_repo.py`. One-line, minimal, no behavior change.

### Risk Assessment
- Impact: High (backend is currently down)
- Scope: Single import line in one file
- Testing: Verified `from app.main import app` imports cleanly locally; full pytest suite run — 213 passed, 31 failed (all pre-existing, unrelated recipe-generation/nutrition test failures, same as baseline before this change)

### Checklist
- [x] Fix verified locally
- [x] No other side effects
- [ ] Tested on production-like data
- [x] Ready for immediate deploy

---
⚠️ This will deploy immediately to production via Railway