### PR TITLE
Restore Claude Code GitHub workflows

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -210,7 +210,7 @@ This project has an extensive design system. **Always follow these rules**:
 
 ## Key Domain Models
 
-### Backend Models (19 model files)
+### Backend Models (17 model files)
 - **User** - Clerk-integrated user with subscription management (`has_pro_access` property), admin flag, cascade relationships to all data
 - **Recipe** - Full recipe with ingredients, directions, dual images (reference + banner), `total_time` hybrid property (prep + cook)
 - **RecipeIngredient** - Junction table (recipe <-> ingredient)
@@ -223,7 +223,6 @@ This project has an extensive design system. **Always follow these rules**:
 - **ShoppingItem** - Shopping list item with aggregation_key for diff-based sync
 - **ShoppingItemContribution** - Source tracking (which recipes contribute to each shopping item)
 - **UnitConversionRule** - Conversion rules (from_unit, to_unit, factor)
-- **Feedback** - User feedback (status: open/reviewed/closed)
 - **UserSettings**, **UserCategory**, **UserIngredientCategory**, **UserIngredientUnit** - User customization models
 - **UserUsage** - AI feature usage tracking per user
 

--- a/.claude/agents/backend-architect.md
+++ b/.claude/agents/backend-architect.md
@@ -25,7 +25,7 @@ You are responsible for all code within the `backend/` directory:
 ## Service Organization
 
 Services follow two patterns:
-- **Flat files** for simple services: `recipe_service.py`, `ingredient_service.py`, `feedback_service.py`, `recipe_group_service.py`, `unit_conversion_service.py`, `usage_service.py`, `user_category_service.py`, `user_service.py`
+- **Flat files** for simple services: `recipe_service.py`, `ingredient_service.py`, `github_service.py`, `recipe_group_service.py`, `unit_conversion_service.py`, `usage_service.py`, `user_category_service.py`, `user_service.py`
 - **Modular packages** for complex services (Core + Mixins composed in `__init__.py`):
   - `services/meal/` — MealServiceCore + SideRecipeMixin + QueryMixin
   - `services/planner/` — PlannerServiceCore + EntryManagementMixin + StatusManagementMixin + BatchOperationsMixin

--- a/.claude/context/backend/services.md
+++ b/.claude/context/backend/services.md
@@ -122,6 +122,6 @@ class MealService(SideRecipeMixin, QueryMixin, MealServiceCore):
 - `services/shopping/` — ShoppingServiceCore + SyncMixin + ItemManagementMixin + AggregationMixin
 - `services/data_management/` — backup.py, export_ops.py, import_ops.py, restore.py
 
-**Simple services remain as flat files:** `recipe_service.py`, `ingredient_service.py`, `feedback_service.py`, `recipe_group_service.py`, `unit_conversion_service.py`, `usage_service.py`, `user_service.py`
+**Simple services remain as flat files:** `recipe_service.py`, `ingredient_service.py`, `github_service.py`, `recipe_group_service.py`, `unit_conversion_service.py`, `usage_service.py`, `user_service.py`
 
 **See:** [app/services/recipe_service.py](../../backend/app/services/recipe_service.py) for flat service reference, and [app/services/meal/](../../backend/app/services/meal/) for modular package reference.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,43 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,68 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Branch from staging instead of main (default branch)
+          base_branch: staging
+
+          # Branch naming: uses GitHub labels (feature, fix, chore) as prefix
+          # Requires issues to have a matching label, otherwise falls back to "claude/"
+          branch_prefix: ""
+          branch_name_template: "{{label}}/issue-{{entityNumber}}-{{timestamp}}"
+
+          additional_permissions: |
+            actions: read
+
+          # Git workflow conventions for commits and PRs
+          prompt: |
+            Follow these git conventions strictly:
+
+            Commit messages: Use conventional commits format
+              <type>: <description>
+            Types: feat, fix, chore, refactor, docs, test, style, perf
+            - Lowercase type, lowercase description, no period at end
+            - Imperative mood ("add" not "added")
+            - Under 72 characters
+
+            PR titles: Derive from branch name or summarize commits
+            PR body: Include Summary, Changes, and Test Plan sections
+
+            Always end commits with:
+            Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+
+            Target all PRs to the staging branch, never to main directly.

--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ backend/app/scripts/copy_prod_to_local.py
 
 # Local task files
 tasks/
-.github/
 
 # Generated outputs
 audits/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,7 +207,7 @@ This project has an extensive design system. **Always follow these rules**:
 
 ## Key Domain Models
 
-### Backend Models (19 model files)
+### Backend Models (17 model files)
 - **User** - Clerk-integrated user with subscription management (`has_pro_access` property), admin flag, cascade relationships to all data
 - **Recipe** - Full recipe with ingredients, directions, dual images (reference + banner), `total_time` hybrid property (prep + cook)
 - **RecipeIngredient** - Junction table (recipe <-> ingredient)
@@ -220,7 +220,6 @@ This project has an extensive design system. **Always follow these rules**:
 - **ShoppingItem** - Shopping list item with aggregation_key for diff-based sync
 - **ShoppingItemContribution** - Source tracking (which recipes contribute to each shopping item)
 - **UnitConversionRule** - Conversion rules (from_unit, to_unit, factor)
-- **Feedback** - User feedback (status: open/reviewed/closed)
 - **UserSettings**, **UserCategory**, **UserIngredientCategory**, **UserIngredientUnit** - User customization models
 - **UserUsage** - AI feature usage tracking per user
 

--- a/backend/app/dtos/admin_dtos.py
+++ b/backend/app/dtos/admin_dtos.py
@@ -1,4 +1,4 @@
-"""Admin panel DTOs for user management and feedback review."""
+"""Admin panel DTOs for user management."""
 
 from __future__ import annotations
 

--- a/docs/BACKEND_DOCUMENTATION.md
+++ b/docs/BACKEND_DOCUMENTATION.md
@@ -199,7 +199,6 @@ See `.env.example` for full list. Key ones:
 | ShoppingItem | Shopping list item | ingredient_name, quantity, unit, aggregation_key, have, flagged |
 | ShoppingItemContribution | Source tracking | shopping_item_id, planner_entry_id |
 | UnitConversionRule | Unit conversion | from_unit, to_unit, conversion_factor |
-| Feedback | User feedback | message, status (open/reviewed/closed), admin_notes |
 | UserSettings | User preferences | Various preference fields |
 | UserCategory | Custom recipe categories | name, user_id |
 | UserIngredientCategory | Custom ingredient categories | name, user_id |

--- a/docs/FRONTEND_DOCUMENTATION.md
+++ b/docs/FRONTEND_DOCUMENTATION.md
@@ -27,7 +27,7 @@ src/
 │   ├── meal-planner/         # Meal planner + create meal
 │   ├── shopping-list/        # Shopping list with categories
 │   ├── settings/             # User settings (appearance, data, AI, etc.)
-│   ├── admin/                # Admin dashboard (users, feedback)
+│   ├── admin/                # Admin dashboard (users, database)
 │   ├── sign-in/              # Clerk sign-in
 │   ├── sign-up/              # Clerk sign-up
 │   ├── sso-callback/         # OAuth callback handler


### PR DESCRIPTION
## Summary
- Restore `.github/workflows/claude.yml` and `claude-code-review.yml`, which were accidentally deleted and then gitignored on 2026-02-07
- Required for `@claude` mentions on issues/PRs to trigger again (GitHub reads workflow definitions for `issue_comment`/`issues` events from the default branch)
- Clean up stale docs (CLAUDE.md, AGENTS.md, backend docs) that still referenced the old DB-backed Feedback model/admin panel, which was already fully removed from code in favor of the GitHub-issue-based feedback flow

## Changes
- `.github/workflows/claude.yml`, `.github/workflows/claude-code-review.yml` — restored
- `.gitignore` — removed the `.github/` entry that was silently blocking these files
- `.claude/CLAUDE.md`, `AGENTS.md`, `.claude/context/backend/services.md`, `.claude/agents/backend-architect.md`, `docs/BACKEND_DOCUMENTATION.md`, `docs/FRONTEND_DOCUMENTATION.md`, `backend/app/dtos/admin_dtos.py` — remove stale Feedback model references

## Test Plan
- [x] Verified `CLAUDE_CODE_OAUTH_TOKEN` secret already exists in repo settings
- [ ] After merge, comment `@claude` on an existing issue and confirm the workflow triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)