### PR TITLE
Fix @claude issue mentions silently no-op'ing

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -48,9 +48,12 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Git workflow conventions for commits and PRs
-          prompt: |
-            Follow these git conventions strictly:
+          # NOTE: do not set `prompt` here — on issue_comment/issues events, the
+          # action forces "agent" mode whenever `prompt` is non-empty, which skips
+          # automatic issue-context injection and reply-comment posting (tag mode).
+          # Use --append-system-prompt instead so @claude mentions keep full context.
+          claude_args: |
+            --append-system-prompt 'Follow these git conventions strictly for any commits or PRs you create:
 
             Commit messages: Use conventional commits format
               <type>: <description>
@@ -65,4 +68,4 @@ jobs:
             Always end commits with:
             Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 
-            Target all PRs to the staging branch, never to main directly.
+            Target all PRs to the staging branch, never to main directly.'


### PR DESCRIPTION
## Summary
- `@claude` comments on issues were triggering the workflow (job ran, succeeded) but Claude never replied
- Root cause: `anthropics/claude-code-action@v1` was updated upstream — it now forces "agent" mode whenever the `prompt` input is set on `issue_comment`/`issues` events, which skips the built-in issue-context injection and reply-comment posting that "tag" mode provides. Confirmed via the action's `detectMode()` source at the SHA our workflow run pulled.
- Our workflow always set `prompt` (for git-convention instructions), so every `@claude` mention silently ran in context-free agent mode: 1 turn, ~$0.10, no comment, no branch, no PR.

## Changes
- `.github/workflows/claude.yml`: move the git-convention instructions from `prompt` to `claude_args: --append-system-prompt '...'`, which layers them on top of the default trigger detection instead of replacing it — restores "tag" mode for `@claude` mentions.

## Test Plan
- [x] Verified the multiline `--append-system-prompt '...'` value round-trips correctly through the action's `shell-quote`-based arg parser (tested locally against the same escape/unescape logic used in `base-action/src/parse-sdk-options.ts`)
- [ ] After merge, comment `@claude` on an issue and confirm Claude actually replies (not just a successful no-op run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)