### PR TITLE
fix: allow vertical scroll on mobile meal cards

### DIFF
--- a/frontend/src/app/(app)/meal-planner/_components/MealGridCard.tsx
+++ b/frontend/src/app/(app)/meal-planner/_components/MealGridCard.tsx
@@ -122,7 +122,10 @@ export function MealGridCard({
       aria-label={`${item.name} — Enter or click to view, Space or hold to reorder`}
       className={cn(
         // Base styles
-        "group cursor-pointer overflow-hidden touch-none",
+        // touch-pan-y (not touch-none) so native vertical scroll still works when a
+        // swipe starts over a card — PointerSensor's 250ms delay + 5px tolerance
+        // (see MealGrid.tsx) is enough to distinguish an intentional drag from a scroll.
+        "group cursor-pointer overflow-hidden touch-pan-y",
         "pb-0 pt-0 gap-0",
         // Liftable hover effect (disabled while dragging to prevent transform conflicts)
         !isDragging && "liftable hover:bg-hover",


### PR DESCRIPTION
## Summary
- Swaps `touch-none` for `touch-pan-y` on `MealGridCard` so native vertical scroll works when a swipe starts over a meal card, while still blocking horizontal panning so drag-to-reorder isn't hijacked by the browser.
- `PointerSensor`'s existing 250ms delay + 5px tolerance activation constraint (in `MealGrid.tsx`) still correctly distinguishes an intentional press-and-hold drag from a scroll gesture.

## Changes
- `frontend/src/app/(app)/meal-planner/_components/MealGridCard.tsx`: `touch-none` → `touch-pan-y` on the card root.

## Test Plan
- [ ] On a mobile device/emulator, verify swiping vertically starting on a meal card scrolls the page.
- [ ] Verify press-and-hold drag-to-reorder still works on touch devices.
- [ ] Verify desktop pointer drag-to-reorder is unaffected.

Closes #144

Generated with [Claude Code](https://claude.ai/code)