### PR TITLE
Fix recipe browser filter persistence across navigation

### DIFF
--- a/frontend/src/components/recipe/RecipeBrowserView.tsx
+++ b/frontend/src/components/recipe/RecipeBrowserView.tsx
@@ -283,7 +283,6 @@ export function RecipeBrowserView({
   const { openAssistant } = useAssistantDialog();
   const toggleFavoriteMutation = useToggleFavorite();
   const { saveFilterState, loadFilterState, clearFilterState } = useRecipeFilterPersistence();
-  const restoredRef = useRef(false);
 
   // Load saved filter state (for back navigation restoration)
   const savedState = useMemo(() => {
@@ -505,14 +504,18 @@ export function RecipeBrowserView({
     }
   }, [mode, searchParams, filters.favoritesOnly, setFilters, setActiveQuickFilters]);
 
-  // Clear saved filter state after restoration
+  // Persist filter state on every change so it survives any navigation path,
+  // not just the back-navigation restore this hook originally supported.
   useEffect(() => {
     if (mode === "select") return;
-    if (savedState && !restoredRef.current) {
-      restoredRef.current = true;
-      clearFilterState();
-    }
-  }, [savedState, clearFilterState, mode]);
+    saveFilterState({
+      filters,
+      searchTerm: filters.searchTerm,
+      activeQuickFilters: Array.from(activeQuickFilters),
+      sortBy,
+      sortDirection,
+    });
+  }, [mode, filters, activeQuickFilters, sortBy, sortDirection, saveFilterState]);
 
   // Scroll position restore on back navigation
   useEffect(() => {
@@ -573,13 +576,6 @@ export function RecipeBrowserView({
       onSelect?.(recipe);
     } else {
       sessionStorage.setItem(SCROLL_POSITION_KEY, String(window.scrollY));
-      saveFilterState({
-        filters,
-        searchTerm: filters.searchTerm,
-        activeQuickFilters: Array.from(activeQuickFilters),
-        sortBy,
-        sortDirection,
-      });
       router.push(`/recipes/${recipe.id}`);
     }
   };

--- a/frontend/src/hooks/persistence/useRecipeFilterPersistence.ts
+++ b/frontend/src/hooks/persistence/useRecipeFilterPersistence.ts
@@ -47,24 +47,25 @@ interface UseRecipeFilterPersistenceReturn {
 }
 
 /**
- * Hook for persisting recipe filter state across back navigation.
+ * Hook for persisting recipe filter state across navigation.
  *
  * Uses sessionStorage so state persists within a browser tab session
- * but resets when the tab is closed or on fresh navigation.
+ * but resets when the tab is closed. Callers should save on every
+ * filter/search/sort change (not just before navigating away) so state
+ * survives any navigation path, not only back-navigation.
  *
  * @example
  * ```tsx
  * const { saveFilterState, loadFilterState, clearFilterState } = useRecipeFilterPersistence();
  *
- * // On click recipe
- * saveFilterState({ filters, searchTerm, activeQuickFilters, sortBy, sortDirection });
- *
  * // On mount - restore if available
  * const saved = loadFilterState();
- * if (saved) {
- *   setFilters(saved.filters);
- *   clearFilterState(); // Prevent stale restoration
- * }
+ *
+ * // Whenever filters/search/quickFilters/sort change
+ * saveFilterState({ filters, searchTerm, activeQuickFilters, sortBy, sortDirection });
+ *
+ * // On explicit "Clear All"
+ * clearFilterState();
  * ```
  */
 export function useRecipeFilterPersistence(): UseRecipeFilterPersistenceReturn {


### PR DESCRIPTION
## Summary
- Filters, search, sort, and quick filters were only saved right before navigating into a recipe detail page, then immediately cleared on restore — a one-shot back-navigation restore, not durable persistence.
- Now saves to sessionStorage whenever filters/search/quickFilters/sort change, so state survives any navigation path (top nav to meal planner, shopping list, dashboard, etc.), not just recipe-detail back-navigation.
- Kept the existing 30-minute staleness guard so filters still reset on a fresh session.

## Changes
- `frontend/src/components/recipe/RecipeBrowserView.tsx`: replaced the one-shot "save on recipe click, clear on restore" effect with a continuous save-on-change effect; removed now-unused `restoredRef`.
- `frontend/src/hooks/persistence/useRecipeFilterPersistence.ts`: updated stale JSDoc example to reflect the new usage pattern.

## Test Plan
- [ ] On `/recipes`, apply filters/search/sort, navigate to meal planner via top nav, then back to `/recipes` — filters should still be applied.
- [ ] Confirm filters still reset after 30 minutes of inactivity.
- [ ] Confirm "Clear All" still clears persisted state.

Fixes #132

Generated with [Claude Code](https://claude.ai/code)