### PR TITLE
Fix duplicate 'other' shopping category from casing mismatch

### DIFF
--- a/backend/app/dtos/shopping_dtos.py
+++ b/backend/app/dtos/shopping_dtos.py
@@ -52,6 +52,16 @@ class ManualItemCreateDTO(BaseModel):
             return v.strip()
         return v
 
+    @field_validator("category", mode="before")
+    @classmethod
+    def normalize_category(cls, v):
+        # Lowercase to match the app's category-slug convention ("produce", "household");
+        # prevents "Other" vs "other" from splitting into two shopping-list groups.
+        if isinstance(v, str):
+            normalized = v.strip().lower()
+            return normalized or None
+        return v
+
 class ExternalItemUpsertDTO(BaseModel):
     """DTO for items pushed by a trusted first-party app via the API-key ingest endpoint.
 
@@ -108,6 +118,16 @@ class ShoppingItemUpdateDTO(BaseModel):
     def strip_ingredient_name(cls, v):
         if isinstance(v, str) and v:
             return v.strip()
+        return v
+
+    @field_validator("category", mode="before")
+    @classmethod
+    def normalize_category(cls, v):
+        # Lowercase to match the app's category-slug convention ("produce", "household");
+        # prevents "Other" vs "other" from splitting into two shopping-list groups.
+        if isinstance(v, str):
+            normalized = v.strip().lower()
+            return normalized or None
         return v
 
 # ── Response DTOs ───────────────────────────────────────────────────────────────────────────────────────────

--- a/backend/app/models/shopping_item.py
+++ b/backend/app/models/shopping_item.py
@@ -212,7 +212,7 @@ class ShoppingItem(Base):
             ingredient_name=ingredient_name,
             quantity=quantity,
             unit=unit,
-            category=category,
+            category=category or "other",
             source="manual",
             have=False
         )

--- a/backend/tests/test_shopping_manual_items.py
+++ b/backend/tests/test_shopping_manual_items.py
@@ -1,0 +1,89 @@
+"""Tests for manual shopping item category handling.
+
+Regression coverage for #136/#143: manual items added without an explicit
+category used to land in a NULL category (client-side "Other" fallback)
+while every other item source used the literal "other" slug, splitting the
+shopping list into two visually-identical "Other" groups.
+"""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.dtos.shopping_dtos import ManualItemCreateDTO, ShoppingItemUpdateDTO
+from app.models.shopping_item import ShoppingItem
+from app.models.user import User
+from app.services.shopping import ShoppingService
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def service(db_session: Session, test_user: User) -> ShoppingService:
+    return ShoppingService(db_session, test_user.id)
+
+
+def make_dto(**overrides) -> ManualItemCreateDTO:
+    data = {"ingredient_name": "Duct Tape", "quantity": 1}
+    data.update(overrides)
+    return ManualItemCreateDTO(**data)
+
+
+# ---------------------------------------------------------------------------
+# DTO validation
+# ---------------------------------------------------------------------------
+
+class TestManualItemCreateDTO:
+    def test_no_category_stays_none(self):
+        dto = make_dto()
+        assert dto.category is None
+
+    def test_category_normalized_to_lowercase(self):
+        dto = make_dto(category="  Household ")
+        assert dto.category == "household"
+
+    def test_empty_category_normalized_to_none(self):
+        dto = make_dto(category="")
+        assert dto.category is None
+
+
+class TestShoppingItemUpdateDTO:
+    def test_category_normalized_to_lowercase(self):
+        dto = ShoppingItemUpdateDTO(category="  Produce ")
+        assert dto.category == "produce"
+
+
+# ---------------------------------------------------------------------------
+# Model factory
+# ---------------------------------------------------------------------------
+
+class TestShoppingItemCreateManual:
+    def test_missing_category_defaults_to_other(self):
+        item = ShoppingItem.create_manual(ingredient_name="Duct Tape", quantity=1)
+        assert item.category == "other"
+
+    def test_explicit_category_preserved(self):
+        item = ShoppingItem.create_manual(
+            ingredient_name="Duct Tape", quantity=1, category="household"
+        )
+        assert item.category == "household"
+
+
+# ---------------------------------------------------------------------------
+# Service integration
+# ---------------------------------------------------------------------------
+
+class TestAddManualItem:
+    def test_item_without_category_gets_other(self, service: ShoppingService):
+        result = service.add_manual_item(make_dto())
+        assert result is not None
+        assert result.category == "other"
+
+    def test_two_uncategorized_items_share_one_category(self, service: ShoppingService):
+        first = service.add_manual_item(make_dto(ingredient_name="Duct Tape"))
+        second = service.add_manual_item(
+            make_dto(ingredient_name="Batteries", category="Other")
+        )
+        assert first is not None and second is not None
+        assert first.category == second.category == "other"

--- a/frontend/src/app/(app)/shopping-list/_components/ShoppingCategory.tsx
+++ b/frontend/src/app/(app)/shopping-list/_components/ShoppingCategory.tsx
@@ -154,7 +154,7 @@ export function ShoppingCategory({
         <div className="flex-1 text-left">
           <div className="flex items-center gap-2">
             <h2 className="text-base font-semibold text-foreground capitalize">
-              {category || "Other"}
+              {category || "other"}
             </h2>
             {isComplete && (
               <Badge variant="success" size="sm" className="text-success font-semibold" >

--- a/frontend/src/app/(app)/shopping-list/_components/ShoppingListView.tsx
+++ b/frontend/src/app/(app)/shopping-list/_components/ShoppingListView.tsx
@@ -120,7 +120,9 @@ export function ShoppingListView() {
 
   const groupedItems = itemsToShow.reduce<Record<string, ShoppingItemResponseDTO[]>>(
     (acc, item) => {
-      const category = item.category || "Other";
+      // Normalize to lowercase so pre-existing rows stored with mismatched casing
+      // (e.g. "Other" vs "other") group together instead of splitting into two sections.
+      const category = (item.category || "other").trim().toLowerCase();
       if (!acc[category]) {
         acc[category] = [];
       }
@@ -264,9 +266,9 @@ export function ShoppingListView() {
 
   // Sort categories based on user preference
   const sortedCategories = Object.keys(groupedItems).sort((a, b) => {
-    // "Other" always goes to the end
-    if (a === "Other") return 1;
-    if (b === "Other") return -1;
+    // "other" always goes to the end
+    if (a === "other") return 1;
+    if (b === "other") return -1;
 
     if (categorySortOrder === "custom" && customCategoryOrder.length > 0) {
       // Use custom order with normalized matching


### PR DESCRIPTION
## Summary
- Root cause: manual shopping items added without picking a category were stored with `category=NULL`, while every other item source (recipe sync, external ingest) always stores the literal slug `"other"`. The frontend grouped items by exact string match, substituting a capitalized `"Other"` fallback only for the NULL case — so `NULL`-backed items and `"other"`-backed items rendered as two separate, visually identical "Other" sections on the shopping list.
- Fixed at the source (new manual items always get a real category) and defensively on read (existing mismatched rows self-heal via case-insensitive grouping, no data migration needed).

## Changes
- `backend/app/models/shopping_item.py`: `ShoppingItem.create_manual` now defaults `category` to `"other"` instead of leaving it `NULL`.
- `backend/app/dtos/shopping_dtos.py`: `ManualItemCreateDTO` and `ShoppingItemUpdateDTO` now normalize `category` (strip + lowercase), mirroring the existing `ExternalItemUpsertDTO` validator.
- `frontend/.../ShoppingListView.tsx`: category grouping/sort key normalized to lowercase instead of a case-sensitive `"Other"` fallback.
- `frontend/.../ShoppingCategory.tsx`: fallback display string updated to match the lowercase convention (CSS `capitalize` still renders it as "Other").
- `backend/tests/test_shopping_manual_items.py` (new): regression coverage for DTO normalization, the model default, and the service-level "two uncategorized items land in the same category" case.

## Test Plan
- [x] `pytest tests/test_shopping_manual_items.py tests/test_shopping_external_ingest.py` — 32 passed
- [x] Full backend suite — no new failures (pre-existing 26 failures in AI/recipe-generation tests, documented as unrelated sync/async test mismatches)
- [x] `npx tsc --noEmit` and `eslint` on changed frontend files — clean
- [ ] Manually add a shopping item from a phone without picking a category, confirm it lands in the existing "Other" section instead of creating a new one
- [ ] Confirm any pre-existing duplicate "Other" sections in a real account merge into one after this deploys (self-heals on read, no migration needed)

Fixes #136, Fixes #143

Generated with [Claude Code](https://claude.ai/code)