### PR TITLE
Fix assistant chat faking success on empty recipe generation

### DIFF
--- a/backend/app/services/ai/assistant/generators.py
+++ b/backend/app/services/ai/assistant/generators.py
@@ -45,6 +45,18 @@ class GeneratorsMixin:
         elif tool_name == "create_recipe":
             # Generate a full recipe with structured JSON
             recipe = await self._generate_recipe_from_args(args, context_data)
+            if recipe is None:
+                # Generation failed or came back hollow (no ingredients) — tell the
+                # user instead of silently handing them an empty recipe draft.
+                return {
+                    "type": "chat",
+                    "response": (
+                        f"Hmm, I had trouble putting together a full recipe for "
+                        f"{args.get('recipe_name', 'that')} — mind asking again, "
+                        f"maybe with a bit more detail?"
+                    ),
+                    "tool_args": args,
+                }
             return {
                 "type": "recipe",
                 "response": f"Here's your {args.get('recipe_name', 'recipe')}! 🎉",
@@ -237,29 +249,30 @@ Use your friendly Meal Genie personality."""
             context_data.get("allowed_categories", []) if context_data else []
         )
 
-        request = RecipeGenerationRequestDTO(
-            prompt="\n".join(prompt_parts),
-            allowed_categories=allowed_categories,
-            preferences=None,
-            generate_image=False,
-            estimate_nutrition=False,
-        )
-        # Override servings in the prompt via preferences if non-default
-        if servings and servings != 4:
-            request.preferences = RecipeGenerationPreferencesDTO(servings=servings)
-
         try:
+            request = RecipeGenerationRequestDTO(
+                prompt="\n".join(prompt_parts),
+                allowed_categories=allowed_categories,
+                preferences=None,
+                generate_image=False,
+                estimate_nutrition=False,
+            )
+            # Override servings in the prompt via preferences if non-default
+            if servings and servings != 4:
+                request.preferences = RecipeGenerationPreferencesDTO(servings=servings)
+
             service = get_recipe_generation_service()
             result = await service.generate(request)
-            if result.success and result.recipe:
+            if result.success and result.recipe and result.recipe.ingredients:
                 return result.recipe
+            logger.warning(
+                f"[Assistant] Recipe generation for '{recipe_name}' produced no "
+                f"usable recipe (success={result.success}, ingredients="
+                f"{len(result.recipe.ingredients) if result.recipe else 0})"
+            )
         except Exception as e:
             logger.warning(f"[Assistant] Recipe generation via service failed: {e}")
 
-        # Fallback: return minimal recipe with just the name
-        return RecipeGeneratedDTO(
-            recipe_name=recipe_name,
-            recipe_category="other",
-            meal_type="dinner",
-            ingredients=[],
-        )
+        # Let the caller know generation failed instead of handing back a
+        # recipe that looks complete but has no ingredients/directions.
+        return None

--- a/backend/tests/test_assistant_recipe_generation.py
+++ b/backend/tests/test_assistant_recipe_generation.py
@@ -1,0 +1,110 @@
+"""Tests for the assistant chat's create_recipe tool.
+
+Regression coverage for #135: when the shared recipe-generation service
+failed or returned a hollow result (no ingredients), the assistant used to
+swallow the failure and hand back a fake "successful" recipe with an empty
+ingredient list and no directions. It should instead report the failure so
+the caller can tell the user, matching how the standalone generation
+endpoint surfaces failures.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.dtos.recipe_generation_dtos import (
+    GeneratedIngredientDTO,
+    RecipeGeneratedDTO,
+    RecipeGenerationResponseDTO,
+)
+from app.services.ai.assistant import AssistantService
+
+
+def _make_service() -> AssistantService:
+    """Build a service instance without running __init__ (skips client setup)."""
+    return AssistantService.__new__(AssistantService)
+
+
+def _full_recipe() -> RecipeGeneratedDTO:
+    return RecipeGeneratedDTO(
+        recipe_name="Tacos",
+        recipe_category="other",
+        meal_type="dinner",
+        directions="1. Cook.\n2. Eat.",
+        ingredients=[
+            GeneratedIngredientDTO(ingredient_name="Tortillas", ingredient_category="bakery"),
+        ],
+    )
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class TestGenerateRecipeFromArgs:
+    async def test_successful_generation_returns_recipe(self):
+        service = _make_service()
+        recipe = _full_recipe()
+        with patch(
+            "app.services.ai.assistant.generators.get_recipe_generation_service"
+        ) as get_service:
+            get_service.return_value.generate = AsyncMock(
+                return_value=RecipeGenerationResponseDTO(success=True, recipe=recipe)
+            )
+            result = await service._generate_recipe_from_args({"recipe_name": "Tacos"})
+
+        assert result is recipe
+
+    async def test_service_exception_returns_none(self):
+        service = _make_service()
+        with patch(
+            "app.services.ai.assistant.generators.get_recipe_generation_service"
+        ) as get_service:
+            get_service.return_value.generate = AsyncMock(side_effect=RuntimeError("boom"))
+            result = await service._generate_recipe_from_args({"recipe_name": "Tacos"})
+
+        assert result is None
+
+    async def test_hollow_success_returns_none(self):
+        """success=True but no ingredients must not be treated as a real recipe."""
+        service = _make_service()
+        hollow = RecipeGeneratedDTO(recipe_name="Tacos", ingredients=[])
+        with patch(
+            "app.services.ai.assistant.generators.get_recipe_generation_service"
+        ) as get_service:
+            get_service.return_value.generate = AsyncMock(
+                return_value=RecipeGenerationResponseDTO(success=True, recipe=hollow)
+            )
+            result = await service._generate_recipe_from_args({"recipe_name": "Tacos"})
+
+        assert result is None
+
+
+class TestHandleFunctionCallCreateRecipe:
+    async def test_successful_recipe_returned_as_recipe_type(self):
+        service = _make_service()
+        recipe = _full_recipe()
+        service._generate_recipe_from_args = AsyncMock(return_value=recipe)
+
+        result = await service._handle_function_call(
+            "create_recipe", {"recipe_name": "Tacos"}, None, contents=[]
+        )
+
+        assert result["type"] == "recipe"
+        assert result["recipe"] is recipe
+
+    async def test_failed_generation_returns_chat_message_not_fake_recipe(self):
+        service = _make_service()
+        service._generate_recipe_from_args = AsyncMock(return_value=None)
+
+        result = await service._handle_function_call(
+            "create_recipe", {"recipe_name": "Tacos"}, None, contents=[]
+        )
+
+        assert result["type"] == "chat"
+        assert result.get("recipe") is None
+        assert result["response"]


### PR DESCRIPTION
## Summary
- Root cause: the Meal Genie chat's `create_recipe` tool (`_generate_recipe_from_args`) caught *any* failure from the shared recipe-generation service — an exception, or a result with no ingredients — and silently substituted a fabricated "successful" recipe (name + category only, `ingredients=[]`, `directions=None`). The API route then treated this as a real success: it generated AI images for the empty recipe and counted it toward usage. The wizard's equivalent endpoint (`/ai/recipe-generation`) surfaces the same class of failure as a real HTTP 500 instead — this asymmetry is why only the chat path produced a "successful" recipe with nothing in it.
- Now the assistant chat surfaces failure the same way the wizard does: `_generate_recipe_from_args` returns `None` for any failure (exception, unsuccessful result, or a result with an empty ingredient list), and `create_recipe` responds with a plain chat message asking the user to try again — no recipe object, no images generated, no usage counted. The frontend (`AssistantChatContent.tsx`) already renders a `recipe: null` response as a normal chat bubble, so no frontend change was needed.
- Also moved `RecipeGenerationRequestDTO` construction inside the try block: `style_notes`/`dietary_restrictions` come straight from whatever Gemini puts in the function-call args, and could previously exceed the DTO's 500-char prompt limit and crash the whole chat turn with a raw 500 instead of degrading to the same friendly retry message.

## Changes
- `backend/app/services/ai/assistant/generators.py`: `_generate_recipe_from_args` returns `None` instead of a fabricated recipe on failure/hollow result; `_handle_function_call`'s `create_recipe` branch responds with a chat message when generation fails instead of always returning `type: "recipe"`.
- `backend/tests/test_assistant_recipe_generation.py` (new): regression coverage for successful generation, service exceptions, hollow "successful" results, and the `create_recipe` handler's response shape in both cases.

## Test Plan
- [x] `pytest tests/test_assistant_recipe_generation.py` — 5 passed
- [x] Full backend suite — no new failures (pre-existing 31 failures in AI/recipe-generation tests, documented as unrelated sync/async test mismatches; unchanged in identity before/after this fix)
- [ ] Manually ask Meal Genie chat to generate a recipe and confirm a real recipe with ingredients/directions still comes back correctly
- [ ] Force a failure (e.g. temporarily point `GEMINI_RECIPE_GENERATION_API_KEY` at an invalid key) and confirm the chat replies with a friendly retry message instead of an empty recipe draft

Fixes #135

Generated with [Claude Code](https://claude.ai/code)