### PR TITLE
Deploy: Filter persistence, shopping category fix, assistant recipe-gen fix

### DIFF
--- a/backend/app/dtos/shopping_dtos.py
+++ b/backend/app/dtos/shopping_dtos.py
@@ -52,6 +52,16 @@ class ManualItemCreateDTO(BaseModel):
             return v.strip()
         return v
 
+    @field_validator("category", mode="before")
+    @classmethod
+    def normalize_category(cls, v):
+        # Lowercase to match the app's category-slug convention ("produce", "household");
+        # prevents "Other" vs "other" from splitting into two shopping-list groups.
+        if isinstance(v, str):
+            normalized = v.strip().lower()
+            return normalized or None
+        return v
+
 class ExternalItemUpsertDTO(BaseModel):
     """DTO for items pushed by a trusted first-party app via the API-key ingest endpoint.
 
@@ -108,6 +118,16 @@ class ShoppingItemUpdateDTO(BaseModel):
     def strip_ingredient_name(cls, v):
         if isinstance(v, str) and v:
             return v.strip()
+        return v
+
+    @field_validator("category", mode="before")
+    @classmethod
+    def normalize_category(cls, v):
+        # Lowercase to match the app's category-slug convention ("produce", "household");
+        # prevents "Other" vs "other" from splitting into two shopping-list groups.
+        if isinstance(v, str):
+            normalized = v.strip().lower()
+            return normalized or None
         return v
 
 # ── Response DTOs ───────────────────────────────────────────────────────────────────────────────────────────

--- a/backend/app/models/shopping_item.py
+++ b/backend/app/models/shopping_item.py
@@ -212,7 +212,7 @@ class ShoppingItem(Base):
             ingredient_name=ingredient_name,
             quantity=quantity,
             unit=unit,
-            category=category,
+            category=category or "other",
             source="manual",
             have=False
         )

--- a/backend/app/services/ai/assistant/generators.py
+++ b/backend/app/services/ai/assistant/generators.py
@@ -45,6 +45,18 @@ class GeneratorsMixin:
         elif tool_name == "create_recipe":
             # Generate a full recipe with structured JSON
             recipe = await self._generate_recipe_from_args(args, context_data)
+            if recipe is None:
+                # Generation failed or came back hollow (no ingredients) — tell the
+                # user instead of silently handing them an empty recipe draft.
+                return {
+                    "type": "chat",
+                    "response": (
+                        f"Hmm, I had trouble putting together a full recipe for "
+                        f"{args.get('recipe_name', 'that')} — mind asking again, "
+                        f"maybe with a bit more detail?"
+                    ),
+                    "tool_args": args,
+                }
             return {
                 "type": "recipe",
                 "response": f"Here's your {args.get('recipe_name', 'recipe')}! 🎉",
@@ -237,29 +249,30 @@ Use your friendly Meal Genie personality."""
             context_data.get("allowed_categories", []) if context_data else []
         )
 
-        request = RecipeGenerationRequestDTO(
-            prompt="\n".join(prompt_parts),
-            allowed_categories=allowed_categories,
-            preferences=None,
-            generate_image=False,
-            estimate_nutrition=False,
-        )
-        # Override servings in the prompt via preferences if non-default
-        if servings and servings != 4:
-            request.preferences = RecipeGenerationPreferencesDTO(servings=servings)
-
         try:
+            request = RecipeGenerationRequestDTO(
+                prompt="\n".join(prompt_parts),
+                allowed_categories=allowed_categories,
+                preferences=None,
+                generate_image=False,
+                estimate_nutrition=False,
+            )
+            # Override servings in the prompt via preferences if non-default
+            if servings and servings != 4:
+                request.preferences = RecipeGenerationPreferencesDTO(servings=servings)
+
             service = get_recipe_generation_service()
             result = await service.generate(request)
-            if result.success and result.recipe:
+            if result.success and result.recipe and result.recipe.ingredients:
                 return result.recipe
+            logger.warning(
+                f"[Assistant] Recipe generation for '{recipe_name}' produced no "
+                f"usable recipe (success={result.success}, ingredients="
+                f"{len(result.recipe.ingredients) if result.recipe else 0})"
+            )
         except Exception as e:
             logger.warning(f"[Assistant] Recipe generation via service failed: {e}")
 
-        # Fallback: return minimal recipe with just the name
-        return RecipeGeneratedDTO(
-            recipe_name=recipe_name,
-            recipe_category="other",
-            meal_type="dinner",
-            ingredients=[],
-        )
+        # Let the caller know generation failed instead of handing back a
+        # recipe that looks complete but has no ingredients/directions.
+        return None

--- a/backend/tests/test_assistant_recipe_generation.py
+++ b/backend/tests/test_assistant_recipe_generation.py
@@ -1,0 +1,110 @@
+"""Tests for the assistant chat's create_recipe tool.
+
+Regression coverage for #135: when the shared recipe-generation service
+failed or returned a hollow result (no ingredients), the assistant used to
+swallow the failure and hand back a fake "successful" recipe with an empty
+ingredient list and no directions. It should instead report the failure so
+the caller can tell the user, matching how the standalone generation
+endpoint surfaces failures.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.dtos.recipe_generation_dtos import (
+    GeneratedIngredientDTO,
+    RecipeGeneratedDTO,
+    RecipeGenerationResponseDTO,
+)
+from app.services.ai.assistant import AssistantService
+
+
+def _make_service() -> AssistantService:
+    """Build a service instance without running __init__ (skips client setup)."""
+    return AssistantService.__new__(AssistantService)
+
+
+def _full_recipe() -> RecipeGeneratedDTO:
+    return RecipeGeneratedDTO(
+        recipe_name="Tacos",
+        recipe_category="other",
+        meal_type="dinner",
+        directions="1. Cook.\n2. Eat.",
+        ingredients=[
+            GeneratedIngredientDTO(ingredient_name="Tortillas", ingredient_category="bakery"),
+        ],
+    )
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class TestGenerateRecipeFromArgs:
+    async def test_successful_generation_returns_recipe(self):
+        service = _make_service()
+        recipe = _full_recipe()
+        with patch(
+            "app.services.ai.assistant.generators.get_recipe_generation_service"
+        ) as get_service:
+            get_service.return_value.generate = AsyncMock(
+                return_value=RecipeGenerationResponseDTO(success=True, recipe=recipe)
+            )
+            result = await service._generate_recipe_from_args({"recipe_name": "Tacos"})
+
+        assert result is recipe
+
+    async def test_service_exception_returns_none(self):
+        service = _make_service()
+        with patch(
+            "app.services.ai.assistant.generators.get_recipe_generation_service"
+        ) as get_service:
+            get_service.return_value.generate = AsyncMock(side_effect=RuntimeError("boom"))
+            result = await service._generate_recipe_from_args({"recipe_name": "Tacos"})
+
+        assert result is None
+
+    async def test_hollow_success_returns_none(self):
+        """success=True but no ingredients must not be treated as a real recipe."""
+        service = _make_service()
+        hollow = RecipeGeneratedDTO(recipe_name="Tacos", ingredients=[])
+        with patch(
+            "app.services.ai.assistant.generators.get_recipe_generation_service"
+        ) as get_service:
+            get_service.return_value.generate = AsyncMock(
+                return_value=RecipeGenerationResponseDTO(success=True, recipe=hollow)
+            )
+            result = await service._generate_recipe_from_args({"recipe_name": "Tacos"})
+
+        assert result is None
+
+
+class TestHandleFunctionCallCreateRecipe:
+    async def test_successful_recipe_returned_as_recipe_type(self):
+        service = _make_service()
+        recipe = _full_recipe()
+        service._generate_recipe_from_args = AsyncMock(return_value=recipe)
+
+        result = await service._handle_function_call(
+            "create_recipe", {"recipe_name": "Tacos"}, None, contents=[]
+        )
+
+        assert result["type"] == "recipe"
+        assert result["recipe"] is recipe
+
+    async def test_failed_generation_returns_chat_message_not_fake_recipe(self):
+        service = _make_service()
+        service._generate_recipe_from_args = AsyncMock(return_value=None)
+
+        result = await service._handle_function_call(
+            "create_recipe", {"recipe_name": "Tacos"}, None, contents=[]
+        )
+
+        assert result["type"] == "chat"
+        assert result.get("recipe") is None
+        assert result["response"]

--- a/backend/tests/test_shopping_manual_items.py
+++ b/backend/tests/test_shopping_manual_items.py
@@ -1,0 +1,89 @@
+"""Tests for manual shopping item category handling.
+
+Regression coverage for #136/#143: manual items added without an explicit
+category used to land in a NULL category (client-side "Other" fallback)
+while every other item source used the literal "other" slug, splitting the
+shopping list into two visually-identical "Other" groups.
+"""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.dtos.shopping_dtos import ManualItemCreateDTO, ShoppingItemUpdateDTO
+from app.models.shopping_item import ShoppingItem
+from app.models.user import User
+from app.services.shopping import ShoppingService
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def service(db_session: Session, test_user: User) -> ShoppingService:
+    return ShoppingService(db_session, test_user.id)
+
+
+def make_dto(**overrides) -> ManualItemCreateDTO:
+    data = {"ingredient_name": "Duct Tape", "quantity": 1}
+    data.update(overrides)
+    return ManualItemCreateDTO(**data)
+
+
+# ---------------------------------------------------------------------------
+# DTO validation
+# ---------------------------------------------------------------------------
+
+class TestManualItemCreateDTO:
+    def test_no_category_stays_none(self):
+        dto = make_dto()
+        assert dto.category is None
+
+    def test_category_normalized_to_lowercase(self):
+        dto = make_dto(category="  Household ")
+        assert dto.category == "household"
+
+    def test_empty_category_normalized_to_none(self):
+        dto = make_dto(category="")
+        assert dto.category is None
+
+
+class TestShoppingItemUpdateDTO:
+    def test_category_normalized_to_lowercase(self):
+        dto = ShoppingItemUpdateDTO(category="  Produce ")
+        assert dto.category == "produce"
+
+
+# ---------------------------------------------------------------------------
+# Model factory
+# ---------------------------------------------------------------------------
+
+class TestShoppingItemCreateManual:
+    def test_missing_category_defaults_to_other(self):
+        item = ShoppingItem.create_manual(ingredient_name="Duct Tape", quantity=1)
+        assert item.category == "other"
+
+    def test_explicit_category_preserved(self):
+        item = ShoppingItem.create_manual(
+            ingredient_name="Duct Tape", quantity=1, category="household"
+        )
+        assert item.category == "household"
+
+
+# ---------------------------------------------------------------------------
+# Service integration
+# ---------------------------------------------------------------------------
+
+class TestAddManualItem:
+    def test_item_without_category_gets_other(self, service: ShoppingService):
+        result = service.add_manual_item(make_dto())
+        assert result is not None
+        assert result.category == "other"
+
+    def test_two_uncategorized_items_share_one_category(self, service: ShoppingService):
+        first = service.add_manual_item(make_dto(ingredient_name="Duct Tape"))
+        second = service.add_manual_item(
+            make_dto(ingredient_name="Batteries", category="Other")
+        )
+        assert first is not None and second is not None
+        assert first.category == second.category == "other"

--- a/frontend/src/app/(app)/meal-planner/_components/MealGridCard.tsx
+++ b/frontend/src/app/(app)/meal-planner/_components/MealGridCard.tsx
@@ -122,7 +122,10 @@ export function MealGridCard({
       aria-label={`${item.name} — Enter or click to view, Space or hold to reorder`}
       className={cn(
         // Base styles
-        "group cursor-pointer overflow-hidden touch-none",
+        // touch-pan-y (not touch-none) so native vertical scroll still works when a
+        // swipe starts over a card — PointerSensor's 250ms delay + 5px tolerance
+        // (see MealGrid.tsx) is enough to distinguish an intentional drag from a scroll.
+        "group cursor-pointer overflow-hidden touch-pan-y",
         "pb-0 pt-0 gap-0",
         // Liftable hover effect (disabled while dragging to prevent transform conflicts)
         !isDragging && "liftable hover:bg-hover",

--- a/frontend/src/app/(app)/shopping-list/_components/ShoppingCategory.tsx
+++ b/frontend/src/app/(app)/shopping-list/_components/ShoppingCategory.tsx
@@ -154,7 +154,7 @@ export function ShoppingCategory({
         <div className="flex-1 text-left">
           <div className="flex items-center gap-2">
             <h2 className="text-base font-semibold text-foreground capitalize">
-              {category || "Other"}
+              {category || "other"}
             </h2>
             {isComplete && (
               <Badge variant="success" size="sm" className="text-success font-semibold" >

--- a/frontend/src/app/(app)/shopping-list/_components/ShoppingListView.tsx
+++ b/frontend/src/app/(app)/shopping-list/_components/ShoppingListView.tsx
@@ -120,7 +120,9 @@ export function ShoppingListView() {
 
   const groupedItems = itemsToShow.reduce<Record<string, ShoppingItemResponseDTO[]>>(
     (acc, item) => {
-      const category = item.category || "Other";
+      // Normalize to lowercase so pre-existing rows stored with mismatched casing
+      // (e.g. "Other" vs "other") group together instead of splitting into two sections.
+      const category = (item.category || "other").trim().toLowerCase();
       if (!acc[category]) {
         acc[category] = [];
       }
@@ -264,9 +266,9 @@ export function ShoppingListView() {
 
   // Sort categories based on user preference
   const sortedCategories = Object.keys(groupedItems).sort((a, b) => {
-    // "Other" always goes to the end
-    if (a === "Other") return 1;
-    if (b === "Other") return -1;
+    // "other" always goes to the end
+    if (a === "other") return 1;
+    if (b === "other") return -1;
 
     if (categorySortOrder === "custom" && customCategoryOrder.length > 0) {
       // Use custom order with normalized matching

--- a/frontend/src/components/recipe/RecipeBrowserView.tsx
+++ b/frontend/src/components/recipe/RecipeBrowserView.tsx
@@ -283,7 +283,6 @@ export function RecipeBrowserView({
   const { openAssistant } = useAssistantDialog();
   const toggleFavoriteMutation = useToggleFavorite();
   const { saveFilterState, loadFilterState, clearFilterState } = useRecipeFilterPersistence();
-  const restoredRef = useRef(false);
 
   // Load saved filter state (for back navigation restoration)
   const savedState = useMemo(() => {
@@ -505,14 +504,18 @@ export function RecipeBrowserView({
     }
   }, [mode, searchParams, filters.favoritesOnly, setFilters, setActiveQuickFilters]);
 
-  // Clear saved filter state after restoration
+  // Persist filter state on every change so it survives any navigation path,
+  // not just the back-navigation restore this hook originally supported.
   useEffect(() => {
     if (mode === "select") return;
-    if (savedState && !restoredRef.current) {
-      restoredRef.current = true;
-      clearFilterState();
-    }
-  }, [savedState, clearFilterState, mode]);
+    saveFilterState({
+      filters,
+      searchTerm: filters.searchTerm,
+      activeQuickFilters: Array.from(activeQuickFilters),
+      sortBy,
+      sortDirection,
+    });
+  }, [mode, filters, activeQuickFilters, sortBy, sortDirection, saveFilterState]);
 
   // Scroll position restore on back navigation
   useEffect(() => {
@@ -573,13 +576,6 @@ export function RecipeBrowserView({
       onSelect?.(recipe);
     } else {
       sessionStorage.setItem(SCROLL_POSITION_KEY, String(window.scrollY));
-      saveFilterState({
-        filters,
-        searchTerm: filters.searchTerm,
-        activeQuickFilters: Array.from(activeQuickFilters),
-        sortBy,
-        sortDirection,
-      });
       router.push(`/recipes/${recipe.id}`);
     }
   };

--- a/frontend/src/data/changelog.ts
+++ b/frontend/src/data/changelog.ts
@@ -2,6 +2,12 @@
 // CHANGELOG - Edit the markdown below
 // ============================================
 const CHANGELOG_MD = `
+## 2026-08-05 - Bug Fixes
+- Recipe Browser filters, search, and sort now stay applied when you navigate away and come back — not just when opening a recipe
+- Fixed a Shopping List bug where manually added items could land in a duplicate "Other" category instead of joining the existing one
+- Meal Genie chat now lets you know if it couldn't put together a full recipe, instead of handing you one with no ingredients or directions
+- Fixed Meal Planner scrolling on mobile — swiping over a meal card now scrolls the page instead of getting stuck
+
 ## 2026-07-20 - New Features
 - External shopping list integration — trusted apps can now push items directly to your Shopping List via a secure API
 

--- a/frontend/src/hooks/persistence/useRecipeFilterPersistence.ts
+++ b/frontend/src/hooks/persistence/useRecipeFilterPersistence.ts
@@ -47,24 +47,25 @@ interface UseRecipeFilterPersistenceReturn {
 }
 
 /**
- * Hook for persisting recipe filter state across back navigation.
+ * Hook for persisting recipe filter state across navigation.
  *
  * Uses sessionStorage so state persists within a browser tab session
- * but resets when the tab is closed or on fresh navigation.
+ * but resets when the tab is closed. Callers should save on every
+ * filter/search/sort change (not just before navigating away) so state
+ * survives any navigation path, not only back-navigation.
  *
  * @example
  * ```tsx
  * const { saveFilterState, loadFilterState, clearFilterState } = useRecipeFilterPersistence();
  *
- * // On click recipe
- * saveFilterState({ filters, searchTerm, activeQuickFilters, sortBy, sortDirection });
- *
  * // On mount - restore if available
  * const saved = loadFilterState();
- * if (saved) {
- *   setFilters(saved.filters);
- *   clearFilterState(); // Prevent stale restoration
- * }
+ *
+ * // Whenever filters/search/quickFilters/sort change
+ * saveFilterState({ filters, searchTerm, activeQuickFilters, sortBy, sortDirection });
+ *
+ * // On explicit "Clear All"
+ * clearFilterState();
  * ```
  */
 export function useRecipeFilterPersistence(): UseRecipeFilterPersistenceReturn {


### PR DESCRIPTION
## Production Deploy

### Changes
- fix: allow vertical scroll on mobile meal cards during drag sensor idle (#144)
- fix: detect image collisions in recipe re-key remediation script (#131, internal tooling — data remediation still pending manual run against prod)
- fix: persist recipe browser filters across all navigation (#132)
- fix: prevent duplicate 'other' shopping category from casing mismatch (#136, #143)
- fix: stop assistant chat from faking a successful recipe generation (#135)
- docs: update changelog for 2026-08-05 release

### Checklist
- [x] Tested on staging (backend pytest, frontend tsc/eslint — see individual PRs #147, #148, #149, #145, #140)
- [x] No console errors
- [x] Verified on mobile
- [x] Changelog updated

---
Merging this PR will trigger Railway auto-deploy to production.