### PR TITLE
feat: add timeout and retry config to gemini client and fetch wrapper

### DIFF
--- a/backend/app/services/ai/gemini_client.py
+++ b/backend/app/services/ai/gemini_client.py
@@ -14,6 +14,18 @@ load_dotenv()
 # Cache of initialized clients keyed by resolved API key
 _clients: dict[str, object] = {}
 
+# Bounded timeout for every Gemini API call, in milliseconds. The SDK's
+# default has no timeout, so a stalled request would otherwise hang forever.
+_REQUEST_TIMEOUT_MS = 60_000
+
+# Retry transient failures (rate limiting and server errors) with capped
+# exponential backoff. The SDK's default is to never retry.
+_RETRY_ATTEMPTS = 3
+_RETRY_INITIAL_DELAY_SECONDS = 1.0
+_RETRY_MAX_DELAY_SECONDS = 10.0
+_RETRY_EXP_BASE = 2.0
+_RETRY_HTTP_STATUS_CODES = [429, 500, 502, 503, 504]
+
 
 def get_gemini_client(api_key_env: str, fallback_env: Optional[str] = None) -> object:
     """Get a lazily-initialized Gemini client for the given API key env var.
@@ -38,7 +50,18 @@ def get_gemini_client(api_key_env: str, fallback_env: Optional[str] = None) -> o
 
     if api_key not in _clients:
         from google import genai
+        from google.genai import types
 
-        _clients[api_key] = genai.Client(api_key=api_key)
+        http_options = types.HttpOptions(
+            timeout=_REQUEST_TIMEOUT_MS,
+            retry_options=types.HttpRetryOptions(
+                attempts=_RETRY_ATTEMPTS,
+                initial_delay=_RETRY_INITIAL_DELAY_SECONDS,
+                max_delay=_RETRY_MAX_DELAY_SECONDS,
+                exp_base=_RETRY_EXP_BASE,
+                http_status_codes=_RETRY_HTTP_STATUS_CODES,
+            ),
+        )
+        _clients[api_key] = genai.Client(api_key=api_key, http_options=http_options)
 
     return _clients[api_key]

--- a/frontend/src/lib/api/ai.ts
+++ b/frontend/src/lib/api/ai.ts
@@ -14,7 +14,7 @@ import type {
   RecipeImportRequestDTO,
   RecipeImportResponseDTO,
 } from "@/types/ai";
-import { fetchApi } from "./base";
+import { AI_TIMEOUT_MS, fetchApi } from "./base";
 
 export const imageGenerationApi = {
   /**
@@ -40,7 +40,8 @@ export const imageGenerationApi = {
           ...(imageType && { image_type: imageType }),
         }),
       },
-      token
+      token,
+      AI_TIMEOUT_MS
     ),
 
   /**
@@ -64,7 +65,8 @@ export const imageGenerationApi = {
           reference_image_data: referenceImageData,
         }),
       },
-      token
+      token,
+      AI_TIMEOUT_MS
     ),
 };
 
@@ -75,7 +77,7 @@ export const cookingTipApi = {
    * @returns Response with cooking tip on success
    */
   getTip: (token?: string | null): Promise<CookingTipResponseDTO> =>
-    fetchApi<CookingTipResponseDTO>("/api/ai/cooking-tip", undefined, token),
+    fetchApi<CookingTipResponseDTO>("/api/ai/cooking-tip", undefined, token, AI_TIMEOUT_MS),
 };
 
 export const mealSuggestionsApi = {
@@ -95,7 +97,8 @@ export const mealSuggestionsApi = {
         method: "POST",
         body: JSON.stringify(request),
       },
-      token
+      token,
+      AI_TIMEOUT_MS
     ),
 };
 
@@ -110,7 +113,8 @@ export const nutritionEstimationApi = {
         method: "POST",
         body: JSON.stringify(request),
       },
-      token
+      token,
+      AI_TIMEOUT_MS
     ),
 };
 
@@ -131,7 +135,8 @@ export const recipeGenerationApi = {
         method: "POST",
         body: JSON.stringify(request),
       },
-      token
+      token,
+      AI_TIMEOUT_MS
     ),
 };
 
@@ -152,7 +157,8 @@ export const recipeImportApi = {
         method: "POST",
         body: JSON.stringify(request),
       },
-      token
+      token,
+      AI_TIMEOUT_MS
     ),
 };
 
@@ -179,7 +185,8 @@ export const AssistantApi = {
           conversation_history: conversationHistory,
         }),
       },
-      token
+      token,
+      AI_TIMEOUT_MS
     ),
 
   /**
@@ -203,7 +210,8 @@ export const AssistantApi = {
           conversation_history: conversationHistory,
         }),
       },
-      token
+      token,
+      AI_TIMEOUT_MS
     ),
 
 };

--- a/frontend/src/lib/api/base.ts
+++ b/frontend/src/lib/api/base.ts
@@ -2,6 +2,11 @@
 
 export const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://192.168.1.213:8000";
 
+// Default request timeout. AI endpoints (image/recipe generation, chat) can
+// legitimately run long, so those call sites pass a larger AI_TIMEOUT_MS.
+export const DEFAULT_TIMEOUT_MS = 30_000;
+export const AI_TIMEOUT_MS = 90_000;
+
 export class ApiError extends Error {
   status: number;
   details?: Record<string, unknown>;
@@ -17,7 +22,8 @@ export class ApiError extends Error {
 export async function fetchApi<T>(
   endpoint: string,
   options?: RequestInit,
-  token?: string | null
+  token?: string | null,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS
 ): Promise<T> {
   const url = `${API_BASE}${endpoint}`;
 
@@ -31,10 +37,24 @@ export async function fetchApi<T>(
     headers["Authorization"] = `Bearer ${token}`;
   }
 
-  const response = await fetch(url, {
-    ...options,
-    headers,
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      ...options,
+      headers,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new ApiError(`Request timed out after ${timeoutMs}ms`, 408);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 
   if (!response.ok) {
     let errorMessage = `API Error: ${response.status}`;


### PR DESCRIPTION
## Summary
- Configure bounded timeout (60s) + capped exponential-backoff retry (3 attempts, 429/5xx) on the shared Gemini client in `backend/app/services/ai/gemini_client.py`.
- Add an `AbortController`-based timeout to the frontend `fetchApi` wrapper in `frontend/src/lib/api/base.ts` (default 30s), with a longer 90s timeout for AI endpoints in `frontend/src/lib/api/ai.ts`.

## Changes
- `backend/app/services/ai/gemini_client.py`: construct `genai.Client` with `http_options` (timeout + retry_options).
- `frontend/src/lib/api/base.ts`: `fetchApi` now takes an optional `timeoutMs` and aborts/throws a clear `ApiError` on timeout.
- `frontend/src/lib/api/ai.ts`: AI endpoints use a 90s timeout instead of the 30s default.

Closes #152.

## Test plan
- [ ] `pip show google-genai` to confirm `HttpOptions/HttpRetryOptions` field names match the resolved SDK version
- [ ] `pytest` in `backend/`
- [ ] `npx tsc --noEmit` and `npm run lint` in `frontend/`
- [ ] Manually trigger an AI feature (e.g. cooking tip or recipe generation) to confirm normal requests still succeed

Generated with [Claude Code](https://claude.ai/code)