### PR TITLE
feat: add slowapi rate limiting to feedback and shopping external routes

### DIFF
--- a/backend/app/api/feedback.py
+++ b/backend/app/api/feedback.py
@@ -1,8 +1,9 @@
 """Feedback API endpoint — creates a GitHub issue from user feedback."""
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from app.api.auth import get_current_user
+from app.core.rate_limit import limiter
 from app.dtos.feedback import FeedbackCreateDTO, FeedbackResponseDTO
 from app.models.user import User
 from app.services.github_service import GitHubIssueError, GitHubService
@@ -11,7 +12,9 @@ router = APIRouter()
 
 
 @router.post("", response_model=FeedbackResponseDTO)
+@limiter.limit("5/minute")
 def submit_feedback(
+    request: Request,
     feedback: FeedbackCreateDTO,
     current_user: User = Depends(get_current_user),
 ) -> FeedbackResponseDTO:

--- a/backend/app/api/shopping.py
+++ b/backend/app/api/shopping.py
@@ -5,10 +5,11 @@ FastAPI router for shopping list endpoints.
 
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from sqlalchemy.orm import Session
 
 from app.api.auth import get_current_user, get_integration_user
+from app.core.rate_limit import limiter
 from app.database.db import get_session
 from app.dtos.shopping_dtos import (
     BulkOperationResultDTO,
@@ -89,7 +90,9 @@ def add_manual_item(
 
 
 @router.post("/external/items", response_model=ExternalItemUpsertResultDTO)
+@limiter.limit("60/minute")
 def upsert_external_item(
+    request: Request,
     item_data: ExternalItemUpsertDTO,
     response: Response,
     session: Session = Depends(get_session),

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -1,0 +1,13 @@
+"""app/core/rate_limit.py
+
+Shared slowapi Limiter instance for throttling abuse-prone endpoints.
+
+Keyed by client IP (`get_remote_address`) rather than user ID, since the
+limiter must also cover unauthenticated/key-authenticated callers (e.g. the
+integration API) uniformly.
+"""
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,11 @@ Main FastAPI application for Meal Genie.
 import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 
+from app.core.rate_limit import limiter
 from app.router import api_router
 
 # Create FastAPI app
@@ -15,6 +19,11 @@ app = FastAPI(
     description="Backend API for the Meal Genie recipe management and meal planning application",
     version="1.0.0",
 )
+
+# Rate limiting (slowapi) - see app/core/rate_limit.py for the shared Limiter
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_middleware(SlowAPIMiddleware)
 
 # Get allowed origins from environment or use wildcard for development
 CORS_ORIGINS = os.environ.get("CORS_ORIGINS", "*").split(",")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,9 @@ fastapi>=0.109.0
 uvicorn[standard]>=0.27.0
 python-multipart>=0.0.6
 
+# Rate Limiting
+slowapi>=0.1.9
+
 # Database
 sqlalchemy>=2.0.0
 alembic>=1.13.0


### PR DESCRIPTION
## Summary
- Adds `slowapi` as the rate-limiting library/middleware for the backend
- Throttles `POST /api/feedback` to 5/minute per IP (creates a real GitHub issue per call)
- Throttles `POST /api/shopping/external/items` to 60/minute per IP (key-authenticated, previously unthrottled)

## Changes
- New `backend/app/core/rate_limit.py`: shared `Limiter` instance keyed by client IP
- `backend/app/main.py`: registers the limiter, 429 exception handler, and `SlowAPIMiddleware`
- `backend/app/api/feedback.py` and `backend/app/api/shopping.py`: apply `@limiter.limit(...)` to the two routes
- `backend/requirements.txt`: added `slowapi>=0.1.9`

Closes #156.

## Test plan
- [ ] `pip install -r backend/requirements.txt`
- [ ] `pytest` (existing suite should still pass)
- [ ] Manually hit `POST /api/feedback` 6+ times in a minute and confirm a 429 is returned
- [ ] Manually hit `POST /api/shopping/external/items` 61+ times in a minute and confirm a 429 is returned

Generated with [Claude Code](https://claude.ai/code)