### PR TITLE
feat: integrate Stripe payment processor (checkout, customer creation, billing portal)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,49 @@
+# backend/.env.example
+#
+# Copy to backend/.env and fill in values for local development.
+# Never commit the real .env file.
+
+# ── Database ─────────────────────────────────────────────────────────────
+# Defaults to a local SQLite file if unset.
+SQLALCHEMY_DATABASE_URL=sqlite:///./meal_genie.db
+
+# ── Auth (Clerk) ─────────────────────────────────────────────────────────
+CLERK_SECRET_KEY=
+CLERK_PUBLISHABLE_KEY=
+# AUTH_DISABLED=true bypasses JWT validation for local dev (uses DEV_USER_ID)
+AUTH_DISABLED=true
+DEV_USER_ID=1
+
+# First-party integration auth (X-API-Key header on /api/shopping/external/*)
+INTEGRATION_API_KEY=
+INTEGRATION_USER_ID=
+
+# ── CORS ─────────────────────────────────────────────────────────────────
+CORS_ORIGINS=http://localhost:3000
+
+# ── Stripe ───────────────────────────────────────────────────────────────
+# Secret key from the Stripe dashboard (sk_test_... / sk_live_...)
+STRIPE_SECRET_KEY=
+# Signing secret for verifying webhook payloads (whsec_...)
+STRIPE_WEBHOOK_SECRET=
+# Price ID for the Pro subscription plan (price_...)
+STRIPE_PRICE_ID_PRO=
+# Base URL of the frontend app, used to build Checkout success/cancel
+# URLs and the billing-portal return URL
+FRONTEND_URL=http://localhost:3000
+
+# ── Gemini AI ────────────────────────────────────────────────────────────
+GEMINI_ASSISTANT_API_KEY=
+GEMINI_TIP_API_KEY=
+GEMINI_IMAGE_API_KEY=
+GEMINI_RECIPE_GENERATION_API_KEY=
+GEMINI_NUTRITION_API_KEY=
+
+# ── Cloudinary (image uploads) ──────────────────────────────────────────
+CLOUDINARY_CLOUD_NAME=
+CLOUDINARY_API_KEY=
+CLOUDINARY_API_SECRET=
+
+# ── GitHub (issue tracking integration) ─────────────────────────────────
+GITHUB_TOKEN=
+GITHUB_REPO=

--- a/backend/app/api/billing.py
+++ b/backend/app/api/billing.py
@@ -1,0 +1,66 @@
+"""app/api/billing.py
+
+FastAPI router for Stripe billing endpoints: Checkout session creation
+and billing-portal link generation.
+
+Note: the Stripe webhook handler (which writes subscription state back
+onto the User) is tracked separately and is not part of this router.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.api.auth import get_current_user
+from app.database.db import get_session
+from app.dtos.billing_dtos import CheckoutSessionResponseDTO, PortalSessionResponseDTO
+from app.models.user import User
+from app.services.billing_service import (
+    BillingService,
+    CheckoutSessionError,
+    PortalSessionError,
+    StripeCustomerError,
+    StripeNotConfiguredError,
+)
+
+router = APIRouter()
+
+
+@router.post("/checkout-session", response_model=CheckoutSessionResponseDTO)
+def create_checkout_session(
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Create a Stripe Checkout session for the Pro subscription.
+
+    Creates the user's Stripe customer on first use. Returns the
+    redirect URL the frontend should send the user to.
+    """
+    service = BillingService(session)
+    try:
+        checkout_url = service.create_checkout_session(current_user)
+    except StripeNotConfiguredError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+    except (StripeCustomerError, CheckoutSessionError) as e:
+        raise HTTPException(status_code=502, detail=str(e))
+    return CheckoutSessionResponseDTO(checkout_url=checkout_url)
+
+
+@router.post("/portal-session", response_model=PortalSessionResponseDTO)
+def create_portal_session(
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Create a Stripe billing-portal session for the current user.
+
+    Returns a URL where the user can manage or cancel their subscription.
+    """
+    service = BillingService(session)
+    try:
+        portal_url = service.create_portal_session(current_user)
+    except StripeNotConfiguredError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+    except PortalSessionError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return PortalSessionResponseDTO(portal_url=portal_url)

--- a/backend/app/core/stripe_config.py
+++ b/backend/app/core/stripe_config.py
@@ -1,0 +1,54 @@
+"""app/core/stripe_config.py
+
+Stripe billing configuration using pydantic-settings.
+Manages API keys, the Pro subscription price ID, and redirect URLs
+used by Checkout and the billing portal.
+"""
+
+import logging
+from functools import lru_cache
+from typing import Optional
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
+
+
+class StripeSettings(BaseSettings):
+    """
+    Stripe settings loaded from environment variables.
+
+    Attributes:
+        stripe_secret_key: Stripe secret key for API calls (sk_xxx)
+        stripe_webhook_secret: Signing secret for verifying webhook events (whsec_xxx)
+        stripe_price_id_pro: Price ID for the Pro subscription plan
+        frontend_url: Base URL of the frontend app, used to build Checkout
+            success/cancel URLs and the billing-portal return URL
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    stripe_secret_key: Optional[str] = None
+    stripe_webhook_secret: Optional[str] = None
+    stripe_price_id_pro: Optional[str] = None
+    frontend_url: str = "http://localhost:3000"
+
+    @property
+    def is_configured(self) -> bool:
+        """Check if Stripe is configured well enough to create checkout sessions."""
+        return bool(self.stripe_secret_key and self.stripe_price_id_pro)
+
+
+@lru_cache()
+def get_stripe_settings() -> StripeSettings:
+    """
+    Get cached Stripe settings instance.
+
+    Uses lru_cache to ensure settings are loaded once and reused,
+    avoiding repeated .env file reads.
+    """
+    return StripeSettings()

--- a/backend/app/dtos/billing_dtos.py
+++ b/backend/app/dtos/billing_dtos.py
@@ -1,0 +1,26 @@
+"""app/dtos/billing_dtos.py
+
+DTOs for Stripe billing endpoints (Checkout session, billing portal).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class CheckoutSessionResponseDTO(BaseModel):
+    """Response DTO for POST /api/billing/checkout-session."""
+
+    checkout_url: str
+
+
+class PortalSessionResponseDTO(BaseModel):
+    """Response DTO for POST /api/billing/portal-session."""
+
+    portal_url: str
+
+
+__all__ = [
+    "CheckoutSessionResponseDTO",
+    "PortalSessionResponseDTO",
+]

--- a/backend/app/repositories/user_repo.py
+++ b/backend/app/repositories/user_repo.py
@@ -150,6 +150,21 @@ class UserRepo:
             user.avatar_url = avatar_url
         return user
 
+    def set_stripe_customer_id(self, user: User, stripe_customer_id: str) -> User:
+        """
+        Persist the Stripe customer ID for a user.
+
+        Args:
+            user: The user to update.
+            stripe_customer_id: The Stripe customer ID (cus_xxx).
+
+        Returns:
+            The updated User (not yet committed).
+        """
+        user.stripe_customer_id = stripe_customer_id
+        self.session.flush()
+        return user
+
     def get_settings(self, user_id: int) -> Optional[UserSettings]:
         """
         Get user settings by user ID.

--- a/backend/app/router.py
+++ b/backend/app/router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter
 
 from app.api import (
     admin,
+    billing,
     categories,
     conversion_rules,
     dashboard,
@@ -55,6 +56,7 @@ api_router.include_router(conversion_rules.router, prefix="/api/unit-conversions
 api_router.include_router(dashboard.router, prefix="/api/dashboard", tags=["dashboard"])
 api_router.include_router(settings.router, prefix="/api/settings", tags=["settings"])
 api_router.include_router(users.router, prefix="/api/users", tags=["users"])
+api_router.include_router(billing.router, prefix="/api/billing", tags=["billing"])
 
 # ── Admin routes ─────────────────────────────────────────────────────────
 api_router.include_router(admin.router, prefix="/api/admin", tags=["admin"])

--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -1,0 +1,157 @@
+"""app/services/billing_service.py
+
+Service layer for Stripe billing: customer creation, Checkout session
+creation, and billing-portal session creation.
+
+This covers only the outbound/checkout half of billing. Subscription
+state itself (tier, status, renewal date) is written by the Stripe
+webhook handler, tracked separately.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import stripe
+from sqlalchemy.orm import Session
+
+from ..core.stripe_config import StripeSettings, get_stripe_settings
+from ..models.user import User
+from ..repositories.user_repo import UserRepo
+
+logger = logging.getLogger(__name__)
+
+
+class StripeNotConfiguredError(Exception):
+    """Raised when required Stripe environment variables are missing."""
+
+
+class StripeCustomerError(Exception):
+    """Raised when creating or retrieving a Stripe customer fails."""
+
+
+class CheckoutSessionError(Exception):
+    """Raised when creating a Stripe Checkout session fails."""
+
+
+class PortalSessionError(Exception):
+    """Raised when creating a Stripe billing-portal session fails."""
+
+
+class BillingService:
+    """Service layer for Stripe billing operations."""
+
+    def __init__(self, session: Session, settings: StripeSettings | None = None):
+        self.session = session
+        self.repo = UserRepo(session)
+        self.settings = settings or get_stripe_settings()
+        if self.settings.stripe_secret_key:
+            stripe.api_key = self.settings.stripe_secret_key
+
+    def _require_configured(self) -> None:
+        if not self.settings.is_configured:
+            raise StripeNotConfiguredError(
+                "Stripe is not configured. Set STRIPE_SECRET_KEY and STRIPE_PRICE_ID_PRO."
+            )
+
+    def get_or_create_customer(self, user: User) -> str:
+        """
+        Return the user's Stripe customer ID, creating one on first use.
+
+        Args:
+            user: The authenticated user.
+
+        Returns:
+            The Stripe customer ID (cus_xxx).
+
+        Raises:
+            StripeNotConfiguredError: Stripe secret key is not set.
+            StripeCustomerError: Stripe API call failed.
+        """
+        if user.stripe_customer_id:
+            return user.stripe_customer_id
+
+        self._require_configured()
+        try:
+            customer = stripe.Customer.create(
+                email=user.email,
+                name=user.name or None,
+                metadata={"user_id": str(user.id)},
+            )
+        except stripe.error.StripeError as e:
+            logger.error(f"Stripe customer creation failed for user {user.id}: {e}")
+            raise StripeCustomerError("Failed to create Stripe customer.") from e
+
+        self.repo.set_stripe_customer_id(user, customer.id)
+        self.session.commit()
+        return customer.id
+
+    def create_checkout_session(self, user: User) -> str:
+        """
+        Create a Stripe Checkout session for the Pro subscription.
+
+        Creates the Stripe customer first if the user doesn't have one yet.
+
+        Args:
+            user: The authenticated user.
+
+        Returns:
+            The Checkout session redirect URL.
+
+        Raises:
+            StripeNotConfiguredError: Stripe secret key or price ID is not set.
+            StripeCustomerError: Customer creation failed.
+            CheckoutSessionError: Checkout session creation failed.
+        """
+        self._require_configured()
+        customer_id = self.get_or_create_customer(user)
+
+        try:
+            checkout_session = stripe.checkout.Session.create(
+                customer=customer_id,
+                mode="subscription",
+                line_items=[{"price": self.settings.stripe_price_id_pro, "quantity": 1}],
+                success_url=f"{self.settings.frontend_url}/settings?checkout=success",
+                cancel_url=f"{self.settings.frontend_url}/settings?checkout=cancelled",
+                client_reference_id=str(user.id),
+            )
+        except stripe.error.StripeError as e:
+            logger.error(f"Stripe checkout session creation failed for user {user.id}: {e}")
+            raise CheckoutSessionError("Failed to create checkout session.") from e
+
+        if not checkout_session.url:
+            raise CheckoutSessionError("Stripe did not return a checkout URL.")
+        return checkout_session.url
+
+    def create_portal_session(self, user: User) -> str:
+        """
+        Create a Stripe billing-portal session for managing or cancelling
+        the user's subscription.
+
+        Args:
+            user: The authenticated user.
+
+        Returns:
+            The billing-portal session URL.
+
+        Raises:
+            StripeNotConfiguredError: Stripe secret key is not set.
+            PortalSessionError: User has no Stripe customer yet, or the
+                Stripe API call failed.
+        """
+        self._require_configured()
+        if not user.stripe_customer_id:
+            raise PortalSessionError(
+                "No billing account found for this user. Subscribe first to manage billing."
+            )
+
+        try:
+            portal_session = stripe.billing_portal.Session.create(
+                customer=user.stripe_customer_id,
+                return_url=f"{self.settings.frontend_url}/settings",
+            )
+        except stripe.error.StripeError as e:
+            logger.error(f"Stripe portal session creation failed for user {user.id}: {e}")
+            raise PortalSessionError("Failed to create billing portal session.") from e
+
+        return portal_session.url

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -37,5 +37,8 @@ google-genai>=1.0.0
 # Recipe import (schema.org extraction from recipe websites)
 recipe-scrapers>=15.0.0
 
+# Payments
+stripe>=11.0.0
+
 # GUI (optional - only needed for desktop app)
 # PySide6>=6.6.0


### PR DESCRIPTION
## Summary
- Adds Stripe SDK + config (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID_PRO`, `FRONTEND_URL`) via a new `StripeSettings`
- Adds `BillingService`: lazy Stripe customer creation, Checkout session creation, billing-portal session creation
- Adds `POST /api/billing/checkout-session` and `POST /api/billing/portal-session` endpoints
- Creates `backend/.env.example` (previously missing) documenting all env vars

## Changes
- `backend/app/core/stripe_config.py` (new)
- `backend/app/services/billing_service.py` (new)
- `backend/app/dtos/billing_dtos.py` (new)
- `backend/app/api/billing.py` (new)
- `backend/app/router.py` (registered billing router)
- `backend/app/repositories/user_repo.py` (added `set_stripe_customer_id`)
- `backend/requirements.txt` (added `stripe>=11.0.0`)
- `backend/.env.example` (new)

Out of scope: the Stripe webhook handler that writes subscription state (tracked separately per the issue), and pricing-page copy (blocked on #161).

## Test plan
- [ ] `pip install -r backend/requirements.txt` and confirm the `stripe` package resolves (could not be verified in the sandbox — no pip/python access)
- [ ] Set `STRIPE_SECRET_KEY`, `STRIPE_PRICE_ID_PRO`, `FRONTEND_URL` in a test Stripe account and hit `POST /api/billing/checkout-session` as an authenticated user — confirm a Stripe customer is created and `stripe_customer_id` is persisted
- [ ] Complete a test Checkout and then hit `POST /api/billing/portal-session` — confirm it returns a valid portal URL
- [ ] Hit both endpoints with Stripe unconfigured — confirm 503
- [ ] Hit portal-session for a user with no `stripe_customer_id` — confirm 400

Generated with [Claude Code](https://claude.ai/code)

Closes #162